### PR TITLE
 PN-9053-fix-warning-in-console-durante-esecuzione-dei-test

### DIFF
--- a/src/test/java/it/pn/frontend/e2e/listeners/Hooks.java
+++ b/src/test/java/it/pn/frontend/e2e/listeners/Hooks.java
@@ -71,7 +71,6 @@ public class Hooks {
     }
 
     protected void chrome(){
-
         WebDriverManager.chromedriver().setup();
         ChromeOptions chromeOptions = new ChromeOptions();
         chromeOptions.addArguments("--lang=it");
@@ -128,14 +127,16 @@ public class Hooks {
                         Headers headers = request.getRequest().getHeaders();
                         if(response.getType().equals(ResourceType.XHR)){
                             NetWorkInfo netWorkInfo = new NetWorkInfo();
-                            netWorkInfo.setAuthorizationBearer(Objects.requireNonNull(headers.get("Authorization")).toString());
-                            netWorkInfo.setRequestId(requestId);
-                            netWorkInfo.setRequestUrl(request.getRequest().getUrl());
-                            netWorkInfo.setRequestMethod(request.getRequest().getMethod());
-                            netWorkInfo.setResponseStatus(response.getResponse().getStatus().toString());
-                            String bodyResponse = devTools.send(Network.getResponseBody(response.getRequestId())).getBody();
-                            netWorkInfo.setResponseBody(bodyResponse);
-                            netWorkInfos.add(netWorkInfo);
+                            if(headers.get("Authorization") != null) {
+                                netWorkInfo.setAuthorizationBearer(Objects.requireNonNull(headers.get("Authorization")).toString());
+                                netWorkInfo.setRequestId(requestId);
+                                netWorkInfo.setRequestUrl(request.getRequest().getUrl());
+                                netWorkInfo.setRequestMethod(request.getRequest().getMethod());
+                                netWorkInfo.setResponseStatus(response.getResponse().getStatus().toString());
+                                String bodyResponse = devTools.send(Network.getResponseBody(response.getRequestId())).getBody();
+                                netWorkInfo.setResponseBody(bodyResponse);
+                                netWorkInfos.add(netWorkInfo);
+                            }
                         }
                     }
                     requests.remove(requestId);


### PR DESCRIPTION
### Description Issue
Some exceptions were caused by a `NULL `assignment to the `Authorization` header attribute. This occurred due to unnecessary redirects that did not require the `Authorization `header.

### Changes:

- added a check to the header before assigning the `Authorizazion`


### How to test
Run any test and verify if the console does not print any exceptions.