### PR TITLE
PN-9865-e-2-e-fix-login-steps-che-falliscono-in-aws

### DIFF
--- a/src/main/java/it/pn/frontend/e2e/pages/destinatario/personaFisica/NotifichePFPage.java
+++ b/src/main/java/it/pn/frontend/e2e/pages/destinatario/personaFisica/NotifichePFPage.java
@@ -56,8 +56,8 @@ public class NotifichePFPage extends BasePage {
         try {
             By titleLabel = By.id("Le tue notifiche-page");
             By tableNotifiche = By.id("notifications-table");
-            this.getWebDriverWait(40).withMessage("Il titolo della pagina Notifiche non è visibile").until(ExpectedConditions.visibilityOfElementLocated(titleLabel));
-            this.getWebDriverWait(40).withMessage("La tabella delle Notifiche non è visibile").until(ExpectedConditions.visibilityOfElementLocated(tableNotifiche));
+            this.getWebDriverWait(30).withMessage("Il titolo della pagina Notifiche non è visibile").until(ExpectedConditions.visibilityOfElementLocated(titleLabel));
+            this.getWebDriverWait(30).withMessage("La tabella delle Notifiche non è visibile").until(ExpectedConditions.visibilityOfElementLocated(tableNotifiche));
             logger.info("Notifiche DE Page caricata");
         } catch (TimeoutException e) {
             logger.error("Notifiche DE Page non caricata con errore : " + e.getMessage());

--- a/src/main/java/it/pn/frontend/e2e/pages/mittente/PiattaformaNotifichePage.java
+++ b/src/main/java/it/pn/frontend/e2e/pages/mittente/PiattaformaNotifichePage.java
@@ -85,8 +85,8 @@ public class PiattaformaNotifichePage extends BasePage {
     public void waitLoadPiattaformaNotifichePAPage() {
         try {
             By notificheTitle = By.id("Notifiche-page");
-            this.getWebDriverWait(this.loadComponentWaitTime).withMessage("Il bottone invia notifica non visibile").until(ExpectedConditions.visibilityOf(this.inviaNuovaNotificaButton));
-            this.getWebDriverWait(this.loadComponentWaitTime).withMessage("Il titolo non è visibile").until(ExpectedConditions.visibilityOfElementLocated(notificheTitle));
+            this.getWebDriverWait(30).withMessage("Il bottone invia notifica non visibile").until(ExpectedConditions.visibilityOf(this.inviaNuovaNotificaButton));
+            this.getWebDriverWait(30).withMessage("Il titolo non è visibile").until(ExpectedConditions.visibilityOfElementLocated(notificheTitle));
             logger.info("Piattaforma Notifiche Page caricata");
         } catch (TimeoutException e) {
             logger.error("Piattaforma Notifiche Page non caricata con errore : " + e.getMessage());
@@ -673,11 +673,11 @@ public class PiattaformaNotifichePage extends BasePage {
         return true;
     }
 
-    public void checkDefaultPagination(){
+    public void checkDefaultPagination() {
         final String defaultNumberOfPage = "10";
-        if(numeroNotificheButton.getText().equals(defaultNumberOfPage)){
+        if (numeroNotificheButton.getText().equals(defaultNumberOfPage)) {
             logger.info("numero di default delle notifiche visualizzate corretto");
-        }else{
+        } else {
             logger.error("numero di default delle notifiche visualizzate non corretto");
             Assert.fail("numero di default delle notifiche visualizzate non corretto");
         }

--- a/src/main/java/it/pn/frontend/e2e/section/destinatario/personaFisica/HeaderPFSection.java
+++ b/src/main/java/it/pn/frontend/e2e/section/destinatario/personaFisica/HeaderPFSection.java
@@ -11,37 +11,37 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HeaderFRSection extends BasePage {
+public class HeaderPFSection extends BasePage {
 
     private static final Logger logger = LoggerFactory.getLogger("HeaderPFSection");
 
     @FindBy(css = "button[aria-label='party-menu-button']")
     WebElement profiloUtenteMenu;
 
-    public HeaderFRSection(WebDriver driver) {
+    public HeaderPFSection(WebDriver driver) {
         super(driver);
     }
 
-    public void waitLoadHeaderDESection(){
-        try{
+    public void waitLoadHeaderDESection() {
+        try {
             By titleLabel = By.cssSelector("a[title='Sito di PagoPA S.p.A.']");
             By menuProfilo = By.cssSelector("button[aria-label='party-menu-button']");
-            this.getWebDriverWait(this.loadComponentWaitTime).withMessage("il titolo del header non è visibile").until(ExpectedConditions.visibilityOfElementLocated(titleLabel));
-            this.getWebDriverWait(this.loadComponentWaitTime).withMessage("menu dell'utente non è visibile").until(ExpectedConditions.visibilityOfElementLocated(menuProfilo));
+            this.getWebDriverWait(30).withMessage("il titolo del header non è visibile").until(ExpectedConditions.visibilityOfElementLocated(titleLabel));
+            this.getWebDriverWait(30).withMessage("menu dell'utente non è visibile").until(ExpectedConditions.visibilityOfElementLocated(menuProfilo));
             logger.info("Header DE Section caricata");
-        } catch (TimeoutException e){
-            logger.error("Header DE Section non caricata con errore : "+e.getMessage());
-            Assert.fail("Header DE Section non caricata con errore : "+e.getMessage());
+        } catch (TimeoutException e) {
+            logger.error("Header DE Section non caricata con errore : " + e.getMessage());
+            Assert.fail("Header DE Section non caricata con errore : " + e.getMessage());
         }
     }
 
-    public void selezionaProfiloUtenteMenu(){
-        this.js().executeScript("arguments[0].scrollIntoView(true);",this.profiloUtenteMenu);
+    public void selezionaProfiloUtenteMenu() {
+        this.js().executeScript("arguments[0].scrollIntoView(true);", this.profiloUtenteMenu);
         logger.info("click sul profilo utente");
-        this.js().executeScript("arguments[0].click()",this.profiloUtenteMenu);
+        this.js().executeScript("arguments[0].click()", this.profiloUtenteMenu);
     }
 
-    public void selezionaVoceEsci(){
+    public void selezionaVoceEsci() {
         By esciVoce = By.xpath("//span[contains(text(),'Esci')]");
         this.getWebDriverWait(30).withMessage("la voce esci non è visibile").until(ExpectedConditions.visibilityOfElementLocated(esciVoce));
         logger.info("click su voce esci");
@@ -51,10 +51,10 @@ public class HeaderFRSection extends BasePage {
     public void waitUrlToken() {
         try {
             this.getWebDriverWait(30).until(ExpectedConditions.urlContains("token"));
-            logger.info("Url token ------------------------>"+driver.getCurrentUrl());
-        }catch (TimeoutException e){
-            logger.error("Url token non trovato con errore:"+e.getMessage());
-            Assert.fail("Url token non trovato con errore:"+e.getMessage());
+            logger.info("Url token ------------------------>" + driver.getCurrentUrl());
+        } catch (TimeoutException e) {
+            logger.error("Url token non trovato con errore:" + e.getMessage());
+            Assert.fail("Url token non trovato con errore:" + e.getMessage());
         }
     }
 }

--- a/src/test/java/it/pn/frontend/e2e/listeners/Hooks.java
+++ b/src/test/java/it/pn/frontend/e2e/listeners/Hooks.java
@@ -62,7 +62,7 @@ public class Hooks {
         if (this.headless != null && this.headless.equalsIgnoreCase("false")) {
             driver.manage().window().maximize();
         }
-        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(20));
         logger.info("firefox driver started");
     }
 

--- a/src/test/java/it/pn/frontend/e2e/listeners/Hooks.java
+++ b/src/test/java/it/pn/frontend/e2e/listeners/Hooks.java
@@ -62,7 +62,7 @@ public class Hooks {
         if (this.headless != null && this.headless.equalsIgnoreCase("false")) {
             driver.manage().window().maximize();
         }
-        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(20));
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
         logger.info("firefox driver started");
     }
 
@@ -84,7 +84,7 @@ public class Hooks {
             driver.manage().window().maximize();
         }
 
-        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(20));
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
 
         devTools = ((HasDevTools) driver).getDevTools();
         devTools.createSession();
@@ -163,7 +163,7 @@ public class Hooks {
             driver.manage().window().maximize();
         }
 
-        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(20));
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
         logger.info("edge driver started");
     }
 

--- a/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaFisica/LoginPersonaFisicaPagoPA.java
+++ b/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaFisica/LoginPersonaFisicaPagoPA.java
@@ -48,27 +48,6 @@ public class LoginPersonaFisicaPagoPA {
         }
     }
 
-//    @Given("PF - Si effettua la login tramite token exchange di {string} e viene visualizzata la dashboard")
-//    public void loginPfConTokenExchange(String datipersonaFisica) {
-//        DataPopulation dataPopulation = new DataPopulation();
-//        this.datiPersonaFisica = dataPopulation.readDataPopulation(datipersonaFisica + ".yaml");
-//        String variabileAmbiente = System.getProperty("environment");
-//        switch (variabileAmbiente) {
-//            case "dev" -> this.driver.get(this.datiPersonaFisica.get("url").toString());
-//            case "test", "uat" ->
-//                    this.driver.get(this.datiPersonaFisica.get("url").toString().replace("dev", variabileAmbiente));
-//            default ->
-//                    Assert.fail("Non stato possibile trovare l'ambiente inserito, Inserisci in -Denvironment test o dev o uat");
-//        }
-//
-//        // Login tramite token exchange
-//        loginPortalePersonaFisicaTramiteTokenExchange(datipersonaFisica);
-//
-//        // Verifica che la dashboard sia visualizzata
-//        homePageDestinatarioVieneVisualizzataCorrettamente();
-//
-//    }
-
     @Given("PF - Si effettua la login tramite token exchange come {string}, e viene visualizzata la dashboard")
     public void loginMittenteConTokenExchange(String personaFisica) {
         DataPopulation dataPopulation = new DataPopulation();

--- a/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaFisica/LoginPersonaFisicaPagoPA.java
+++ b/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaFisica/LoginPersonaFisicaPagoPA.java
@@ -12,7 +12,7 @@ import it.pn.frontend.e2e.listeners.Hooks;
 import it.pn.frontend.e2e.listeners.NetWorkInfo;
 import it.pn.frontend.e2e.pages.destinatario.personaFisica.*;
 import it.pn.frontend.e2e.section.CookiesSection;
-import it.pn.frontend.e2e.section.destinatario.personaFisica.HeaderFRSection;
+import it.pn.frontend.e2e.section.destinatario.personaFisica.HeaderPFSection;
 import it.pn.frontend.e2e.utility.CookieConfig;
 import it.pn.frontend.e2e.utility.DataPopulation;
 import org.junit.Assert;
@@ -32,6 +32,7 @@ public class LoginPersonaFisicaPagoPA {
     private final WebDriver driver = Hooks.driver;
     private final List<NetWorkInfo> netWorkInfos = Hooks.netWorkInfos;
     private Map<String, Object> datiDelegato;
+    private static final String FILE_TOKEN_LOGIN = "tokenLogin.yaml";
 
     @Given("Login Page persona fisica {string} viene visualizzata")
     public void loginPageDestinatarioVieneVisualizzata(String datipersonaFisica) {
@@ -47,26 +48,60 @@ public class LoginPersonaFisicaPagoPA {
         }
     }
 
-    @Given("PF - Si effettua la login tramite token exchange di {string} e viene visualizzata la dashboard")
-    public void loginPfConTokenExchange(String datipersonaFisica) {
+//    @Given("PF - Si effettua la login tramite token exchange di {string} e viene visualizzata la dashboard")
+//    public void loginPfConTokenExchange(String datipersonaFisica) {
+//        DataPopulation dataPopulation = new DataPopulation();
+//        this.datiPersonaFisica = dataPopulation.readDataPopulation(datipersonaFisica + ".yaml");
+//        String variabileAmbiente = System.getProperty("environment");
+//        switch (variabileAmbiente) {
+//            case "dev" -> this.driver.get(this.datiPersonaFisica.get("url").toString());
+//            case "test", "uat" ->
+//                    this.driver.get(this.datiPersonaFisica.get("url").toString().replace("dev", variabileAmbiente));
+//            default ->
+//                    Assert.fail("Non stato possibile trovare l'ambiente inserito, Inserisci in -Denvironment test o dev o uat");
+//        }
+//
+//        // Login tramite token exchange
+//        loginPortalePersonaFisicaTramiteTokenExchange(datipersonaFisica);
+//
+//        // Verifica che la dashboard sia visualizzata
+//        homePageDestinatarioVieneVisualizzataCorrettamente();
+//
+//    }
+
+    @Given("PF - Si effettua la login tramite token exchange come {string}, e viene visualizzata la dashboard")
+    public void loginMittenteConTokenExchange(String personaFisica) {
         DataPopulation dataPopulation = new DataPopulation();
-        this.datiPersonaFisica = dataPopulation.readDataPopulation(datipersonaFisica + ".yaml");
-        String variabileAmbiente = System.getProperty("environment");
-        switch (variabileAmbiente) {
-            case "dev" -> this.driver.get(this.datiPersonaFisica.get("url").toString());
-            case "test", "uat" ->
-                    this.driver.get(this.datiPersonaFisica.get("url").toString().replace("dev", variabileAmbiente));
-            default ->
-                    Assert.fail("Non stato possibile trovare l'ambiente inserito, Inserisci in -Denvironment test o dev o uat");
+        String environment = System.getProperty("environment");
+        String token = "";
+        switch (environment) {
+            case "dev" -> token = personaFisica.equalsIgnoreCase("delegante") ?
+                    dataPopulation.readDataPopulation(FILE_TOKEN_LOGIN).get("tokendevPFDelegante").toString()
+                    :
+                    dataPopulation.readDataPopulation(FILE_TOKEN_LOGIN).get("tokendevPFDelegato").toString();
+            case "test" -> token = personaFisica.equalsIgnoreCase("delegante") ?
+                    dataPopulation.readDataPopulation(FILE_TOKEN_LOGIN).get("tokentestPFDelegante").toString()
+                    :
+                    dataPopulation.readDataPopulation(FILE_TOKEN_LOGIN).get("tokentestPFDelegato").toString();
+            default -> {
+                logger.error("Ambiente non valido");
+                Assert.fail("Ambiente non valido o non trovato!");
+            }
         }
 
-        // Login tramite token exchange
-        loginPortalePersonaFisicaTramiteTokenExchange(datipersonaFisica);
+        // Si effettua il login con token exchange
+        String urlLogin = "https://cittadini." + environment + ".notifichedigitali.it/#token=" + token;
+        this.driver.get(urlLogin);
+        logger.info("Login effettuato con successo");
+        DataPopulation.waitTime(10);
 
-        // Verifica che la dashboard sia visualizzata
-        homePageDestinatarioVieneVisualizzataCorrettamente();
-
+        // Si visualizza la dashboard e si verifica che gli elementi base siano presenti (header e title della pagina)
+        HeaderPFSection headerPFSection = new HeaderPFSection(this.driver);
+        headerPFSection.waitLoadHeaderDESection();
+        NotifichePFPage notifichePFPage = new NotifichePFPage(this.driver);
+        notifichePFPage.waitLoadNotificheDEPage();
     }
+
 
     @When("Login con persona fisica {string}")
     public void loginConDestinatario(String datipersonaFisica) {
@@ -135,8 +170,8 @@ public class LoginPersonaFisicaPagoPA {
         }
 
         confermaDatiSpidPFPage.selezionaConfermaButton();
-        HeaderFRSection headerFRSection = new HeaderFRSection(this.driver);
-        headerFRSection.waitUrlToken();
+        HeaderPFSection headerPFSection = new HeaderPFSection(this.driver);
+        headerPFSection.waitUrlToken();
     }
 
     @Then("Home page persona fisica viene visualizzata correttamente")
@@ -168,8 +203,8 @@ public class LoginPersonaFisicaPagoPA {
         } else {
             logger.warn("Http token persona fisica not found");
         }
-        HeaderFRSection headerFRSection = new HeaderFRSection(this.driver);
-        headerFRSection.waitLoadHeaderDESection();
+        HeaderPFSection headerPFSection = new HeaderPFSection(this.driver);
+        headerPFSection.waitLoadHeaderDESection();
 
         if (!CookieConfig.isCookieEnabled()) {
             cookiesSection = new CookiesSection(this.driver);
@@ -220,10 +255,10 @@ public class LoginPersonaFisicaPagoPA {
 
     @And("Logout da portale persona fisica")
     public void logoutDaPortaleDestinatario() {
-        HeaderFRSection headerFRSection = new HeaderFRSection(this.driver);
-        headerFRSection.waitLoadHeaderDESection();
-        headerFRSection.selezionaProfiloUtenteMenu();
-        headerFRSection.selezionaVoceEsci();
+        HeaderPFSection headerPFSection = new HeaderPFSection(this.driver);
+        headerPFSection.waitLoadHeaderDESection();
+        headerPFSection.selezionaProfiloUtenteMenu();
+        headerPFSection.selezionaVoceEsci();
 
         ComeVuoiAccederePage comeVuoiAccederePage = new ComeVuoiAccederePage(this.driver);
         comeVuoiAccederePage.waitLoadComeVuoiAccederePage();

--- a/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaFisica/NotifichePersonaFisicaPagoPATest.java
+++ b/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaFisica/NotifichePersonaFisicaPagoPATest.java
@@ -8,7 +8,7 @@ import it.pn.frontend.e2e.listeners.Hooks;
 import it.pn.frontend.e2e.pages.destinatario.personaFisica.NotifichePFPage;
 import it.pn.frontend.e2e.pages.mittente.PiattaformaNotifichePage;
 import it.pn.frontend.e2e.section.CookiesSection;
-import it.pn.frontend.e2e.section.destinatario.personaFisica.HeaderFRSection;
+import it.pn.frontend.e2e.section.destinatario.personaFisica.HeaderPFSection;
 import it.pn.frontend.e2e.utility.CookieConfig;
 import it.pn.frontend.e2e.utility.DataPopulation;
 import it.pn.frontend.e2e.utility.DownloadFile;
@@ -41,8 +41,8 @@ public class NotifichePersonaFisicaPagoPATest {
 
     @Then("pagina Piattaforma  Notifiche persona fisica viene visualizzata correttamente")
     public void paginaPiattaformaNotificheDestinatarioVieneVisualizzataCorrettamente() {
-        HeaderFRSection headerFRSection = new HeaderFRSection(this.driver);
-        headerFRSection.waitLoadHeaderDESection();
+        HeaderPFSection headerPFSection = new HeaderPFSection(this.driver);
+        headerPFSection.waitLoadHeaderDESection();
 
         if (!CookieConfig.isCookieEnabled()) {
             CookiesSection cookiesSection = new CookiesSection(this.driver);

--- a/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaFisica/RicercaNotifichePersonaFisicaPATest.java
+++ b/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaFisica/RicercaNotifichePersonaFisicaPATest.java
@@ -6,7 +6,7 @@ import io.cucumber.java.en.When;
 import it.pn.frontend.e2e.common.NotificheDestinatarioPage;
 import it.pn.frontend.e2e.listeners.Hooks;
 import it.pn.frontend.e2e.pages.destinatario.personaFisica.NotifichePFPage;
-import it.pn.frontend.e2e.section.destinatario.personaFisica.HeaderFRSection;
+import it.pn.frontend.e2e.section.destinatario.personaFisica.HeaderPFSection;
 import it.pn.frontend.e2e.utility.DataPopulation;
 import org.junit.Assert;
 import org.openqa.selenium.WebDriver;
@@ -19,25 +19,25 @@ import java.util.Map;
 
 public class RicercaNotifichePersonaFisicaPATest {
     private static final Logger logger = LoggerFactory.getLogger("RicercaNotifichePersonaFisicaTest");
-    private final WebDriver  driver = Hooks.driver;
+    private final WebDriver driver = Hooks.driver;
     private Map<String, Object> datiNotifica = new HashMap<>();
     private Map<String, Object> datiNotificaNonValidoPF;
 
     @When("Si visualizza correttamente la pagina Piattaforma Notifiche persona fisica")
-        public void siVisualizzaCorrettamenteLaPaginaPiattaformaNotificheDestinatario() {
-            logger.info("Verifica visualizzazione piattaforma notifiche persona fisica");
-            HeaderFRSection headerFRSection = new HeaderFRSection(this.driver);
-            headerFRSection.waitLoadHeaderDESection();
+    public void siVisualizzaCorrettamenteLaPaginaPiattaformaNotificheDestinatario() {
+        logger.info("Verifica visualizzazione piattaforma notifiche persona fisica");
+        HeaderPFSection headerPFSection = new HeaderPFSection(this.driver);
+        headerPFSection.waitLoadHeaderDESection();
 
-            NotifichePFPage notifichePFPage = new NotifichePFPage(this.driver);
-            notifichePFPage.waitLoadNotificheDEPage();
-        }
+        NotifichePFPage notifichePFPage = new NotifichePFPage(this.driver);
+        notifichePFPage.waitLoadNotificheDEPage();
+    }
 
     @And("Nella pagina Piattaforma Notifiche  persona fisica inserire il codice IUN da dati notifica {string}")
     public void nellaPaginaPiattaformaNotificheDestinatarioInserireIlCodiceIUNDaDatiNotifica(String dpDataNotifica) throws InterruptedException {
         logger.info("Si inserisce il codice IUN");
         DataPopulation dataPopulation = new DataPopulation();
-        this.datiNotifica = dataPopulation.readDataPopulation(dpDataNotifica+".yaml");
+        this.datiNotifica = dataPopulation.readDataPopulation(dpDataNotifica + ".yaml");
         NotifichePFPage notifichePFPage = new NotifichePFPage(this.driver);
         notifichePFPage.waitLoadPage();
 
@@ -56,21 +56,21 @@ public class RicercaNotifichePersonaFisicaPATest {
     @Then("Nella pagina Piattaforma Notifiche persona fisica vengo restituite tutte le notifiche con il codice IUN della notifica {string}")
     public void nellaPaginaPiattaformaNotificheDestinatarioVengoRestituiteTutteLeNotificheConIlCodiceIUNDellaNotifica(String dpDatiNotifica) {
         logger.info("Si verificano i risultati restituiti");
-        HeaderFRSection headerFRSection = new HeaderFRSection(this.driver);
-        headerFRSection.waitLoadHeaderDESection();
+        HeaderPFSection headerPFSection = new HeaderPFSection(this.driver);
+        headerPFSection.waitLoadHeaderDESection();
 
         NotifichePFPage notifichePFPage = new NotifichePFPage(this.driver);
         notifichePFPage.waitLoadNotificheDEPage();
 
         DataPopulation dataPopulation = new DataPopulation();
-        this.datiNotifica = dataPopulation.readDataPopulation(dpDatiNotifica+".yaml");
+        this.datiNotifica = dataPopulation.readDataPopulation(dpDatiNotifica + ".yaml");
         String codiceIUNInserito = datiNotifica.get("codiceIUN").toString();
 
         NotificheDestinatarioPage notificheDestinatarioPage = new NotificheDestinatarioPage(this.driver);
         boolean result = notificheDestinatarioPage.verificaCodiceIUN(codiceIUNInserito);
-        if (result){
+        if (result) {
             logger.info("Il risultato é coerente con il codice IUN inserito");
-        }else {
+        } else {
             logger.error("Il risultato NON é coerente con il codice IUN inserito");
             Assert.fail("Il risultato NON é coerente con il coodice IUN inserito");
         }
@@ -84,20 +84,20 @@ public class RicercaNotifichePersonaFisicaPATest {
         LocalDate dataInizio = dataFine.minusDays(5);
         String dataDA = notifichePFPage.controlloDateInserite(dataInizio.toString());
         String dataA = notifichePFPage.controlloDateInserite(dataFine.toString());
-        notifichePFPage.inserimentoArcoTemporale(dataDA,dataA);
+        notifichePFPage.inserimentoArcoTemporale(dataDA, dataA);
     }
 
     @Then("Nella pagina Piattaforma Notifiche persona fisica vengo restituite tutte le notifiche con la data della notifica compresa con le date precedentemente inserite")
     public void nellaPaginaPiattaformaNotificheDestinatarioVengoRestituiteTutteLeNotificheConLaDataDellaNotificaCompresaTraDaEA() {
-        HeaderFRSection headerFRSection = new HeaderFRSection(this.driver);
-        headerFRSection.waitLoadHeaderDESection();
+        HeaderPFSection headerPFSection = new HeaderPFSection(this.driver);
+        headerPFSection.waitLoadHeaderDESection();
 
         NotifichePFPage notifichePFPage = new NotifichePFPage(this.driver);
         notifichePFPage.waitLoadNotificheDEPage();
         boolean result = notifichePFPage.getListData();
-        if (result){
+        if (result) {
             logger.info("Il risultato é coerente con le date inserite");
-        }else {
+        } else {
             logger.error("Il risultato NON é coerente con le date inserite");
             Assert.fail("Il risultato NON é coerente con le date inserite");
         }
@@ -109,13 +109,13 @@ public class RicercaNotifichePersonaFisicaPATest {
 
         NotifichePFPage notifichePFPage = new NotifichePFPage(this.driver);
 
-        if(notifichePFPage.verificaEsistenzaEPassaggioPagina()){
+        if (notifichePFPage.verificaEsistenzaEPassaggioPagina()) {
             logger.info("Bottone pagina 2 trovato e cliccato");
 
-            HeaderFRSection headerFRSection = new HeaderFRSection(this.driver);
-            headerFRSection.waitLoadHeaderDESection();
+            HeaderPFSection headerPFSection = new HeaderPFSection(this.driver);
+            headerPFSection.waitLoadHeaderDESection();
             notifichePFPage.waitLoadNotificheDEPage();
-        }else {
+        } else {
             logger.info("Bottone pagina 2 non trovato non effettuato il passaggio di pagina");
         }
     }

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/001_001_invioNotificaSezioneInformazioniPreliminari.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/001_001_invioNotificaSezioneInformazioniPreliminari.feature
@@ -6,7 +6,7 @@ Feature: Il mittente inserisce i dati nella sezione informazioni preliminari
   @invioNotifiche
 
   Scenario: PN-9127 - Il mittente inserisce i dati nella sezione informazioni preliminari
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari
     And Nella section Informazioni preliminari inserire i dati della notifica "datiNotifica" senza pagamento

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/001_0C1_invioNuovaNotificaConCampiVuoti.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/001_0C1_invioNuovaNotificaConCampiVuoti.feature
@@ -6,7 +6,7 @@ Feature: Il mittente inserisce i dati di una nuova notifica, dopo l'inserzione d
   @invioNotifiche
 
   Scenario: PN-8895 - Il mittente inserisce i dati non corretti nella sezione informazioni preliminari
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari
     And Nella section Informazioni preliminari inserire i dati della notifica "datiNotifica" senza pagamento

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/002_001_neg_iniviNotificaSezioneInformazioniPreliminariDatiErrati.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/002_001_neg_iniviNotificaSezioneInformazioniPreliminariDatiErrati.feature
@@ -6,7 +6,7 @@ Feature: Il mittente inserisce i dati non coretti nella sezione informazioni pre
   @invioNotifiche
 
   Scenario:Il mittente inserisce i dati non corretti nella sezione informazioni preliminari
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari
     And Nella section si prova ad cliccare sul tasto continua senza aver inserito nessun dato

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/003_002_invioNotificaSezioneDestinatario.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/003_002_invioNotificaSezioneDestinatario.feature
@@ -6,7 +6,7 @@ Feature: il mittente inserisce i dati fino alla sezione Destinatario
     @invioNotifiche
 
   Scenario Outline: PN-9136 - il mittente inserisce i dati fino alla sezione Destinatario
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari
     And Nella section Informazioni preliminari inserire i dati della notifica "datiNotifica" senza pagamento

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/004_002_neg_invioNotificaSezioneDestinatarioErrore.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/004_002_neg_invioNotificaSezioneDestinatarioErrore.feature
@@ -6,7 +6,7 @@ Feature: il mittente inserisce i dati  sbagliati fino alla sezione Destinatario
   @invioNotifiche
 
   Scenario: PN-9314 - il mittente inserisce i dati sbagliati fino alla sezione Destinatario
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari
     And Nella section Informazioni preliminari inserire i dati della notifica "datiNotifica" senza pagamento

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/004_0C2_checkAggiuntaCancellazioneDestinatario.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/004_0C2_checkAggiuntaCancellazioneDestinatario.feature
@@ -6,7 +6,7 @@ Feature: Il mittente inserisce 2 destinatari e viene eliminato il primo
   @invioNotifiche
 
   Scenario: PN-8902 - il mittente inserisce i dati sbagliati fino alla sezione Destinatario
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari
     And Nella section Informazioni preliminari inserire i dati della notifica "datiNotifica" senza pagamento

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/005_003_invioNotificaSezioneAllegati.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/005_003_invioNotificaSezioneAllegati.feature
@@ -6,7 +6,7 @@ Feature: il mittente inserisce tutti i dati di una notifica
     @invioNotifiche
 
   Scenario Outline: PN-9215 - il mittente inserisce tutti i dati di una notifica
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche si recupera l ultimo numero protocollo
     And Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/006_003_neg_ invioNotificaSezioneAllegatiErrore.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/006_003_neg_ invioNotificaSezioneAllegatiErrore.feature
@@ -6,7 +6,7 @@ Feature: il mittente inserisce tutti i dati di una notifica senza allegati
   @invioNotifiche
 
   Scenario: PN-9642 - il mittente inserisce tutti i dati di una notifica senza allegati
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari
     And Nella section Informazioni preliminari inserire i dati della notifica "datiNotifica" senza pagamento

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/007_080_invioNotificaMultiSenzaPagamento.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/007_080_invioNotificaMultiSenzaPagamento.feature
@@ -6,7 +6,7 @@ Feature: Mittente genera una notifica con più destinatari che non prevede pagam
     @invioNotifiche
 
   Scenario Outline: PN-9226 - Mittente genera una notifica con più destinatari che non prevede pagamento
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche si recupera l ultimo numero protocollo
     And Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/008_081_invioNotificaMultiSenzaPagamento6destinatario.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/008_081_invioNotificaMultiSenzaPagamento6destinatario.feature
@@ -6,7 +6,7 @@ Feature: il mittente invia una notifica con 6 destinatario
     @invioNotifiche
 
   Scenario Outline: PN-9227 - il mittente invia una notifica con 6 destinatario
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari
     And Nella section Informazioni preliminari inserire i dati della notifica "datiNotifica" senza pagamento

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/009_082_invioNotificaConStessoCF.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/009_082_invioNotificaConStessoCF.feature
@@ -6,7 +6,7 @@ Feature: invio notifica con lo stesso codice fiscale
   @invioNotifiche
 
   Scenario: PN-9643 - il mittente invia la notifica con lo stesso codice fiscale
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari
     And Nella section Informazioni preliminari inserire i dati della notifica "datiNotifica" senza pagamento

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/010_086_invioNotificaPec.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/010_086_invioNotificaPec.feature
@@ -6,7 +6,7 @@ Feature: Mittente genera una notifica tramite destinatario con pec
   @invioNotifiche
 
   Scenario: PN-9644 - Mittente genera una notifica tramite destinatario con pec
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche si recupera l ultimo numero protocollo
     And Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/011_085_invioNotificaMonoSenzaPagamento.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/011_085_invioNotificaMonoSenzaPagamento.feature
@@ -6,7 +6,7 @@ Feature: Mittente genera una notifica che non prevede pagamento
   @invioNotifiche
 
   Scenario: PN-9645 - Mittente genera una notifica senza pagamento
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche si recupera l ultimo numero protocollo
     And Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari

--- a/src/test/resources/feature/2-mittente/1_invioNotifiche/012_127_invioNotificaCapInesistente.feature
+++ b/src/test/resources/feature/2-mittente/1_invioNotifiche/012_127_invioNotificaCapInesistente.feature
@@ -6,7 +6,7 @@ Feature: invio notifica con lo stesso codice fiscale
   @invioNotifiche
 
   Scenario: PN-9646 - il mittente invia la notifica con CAP inesistente
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche cliccare sul bottone Invia una nuova notifica
     And Si visualizza correttamente la pagina Piattaforma Notifiche section Informazioni preliminari
     And Nella section Informazioni preliminari inserire i dati della notifica "datiNotifica" senza pagamento

--- a/src/test/resources/feature/2-mittente/2_ricercaNotifiche/008_NEG_ricercaPerCodiceFiscaleSbagliato.feature
+++ b/src/test/resources/feature/2-mittente/2_ricercaNotifiche/008_NEG_ricercaPerCodiceFiscaleSbagliato.feature
@@ -7,7 +7,7 @@ Feature: Mittente effetua una ricerca notifiche per CF sbagliato
   @ricercaNatoficheMittente
 
   Scenario: PN-9321 - Mittente loggato effettua una ricerca per CF sbagliato
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche inserire il codice fiscale sbagliato "QWERTY123"
     Then Nella pagina Piattaforma Notifiche si controlla che si visualizza il messaggio di errore codice fiscale
     And Nella pagina Piattaforma Notifiche si controlla che il bottone Filtra sia attivo

--- a/src/test/resources/feature/2-mittente/2_ricercaNotifiche/008_ricercaPerCodiceFiscale.feature
+++ b/src/test/resources/feature/2-mittente/2_ricercaNotifiche/008_ricercaPerCodiceFiscale.feature
@@ -6,7 +6,7 @@ Feature: Mittente effetua una ricerca notifiche per CF
   @ricercaNatoficheMittente
 
   Scenario: PN-9217 - Mittente loggato effettua una ricerca per CF
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche inserire il codice fiscale della persona fisica "personaFisica"
     And Cliccare sul bottone Filtra
     Then Nella pagina Piattaforma Notifiche vengo restituite tutte le notifiche con il codice fiscale del destinatario "personaFisica"

--- a/src/test/resources/feature/2-mittente/2_ricercaNotifiche/009_NEG_ricercaPerCodiceIUNSbagliato.feature
+++ b/src/test/resources/feature/2-mittente/2_ricercaNotifiche/009_NEG_ricercaPerCodiceIUNSbagliato.feature
@@ -6,7 +6,7 @@ Feature: Mittente effetua una ricerca notifiche per codice IUN sbagliato
   @TestSuite
 
   Scenario: PN-9322 - Mittente loggato effettua una ricerca per codice IUN sbagliato
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche inserire il codice IUN sbagliato "NYUM-RLWQ-JDTP-202308"
     Then Nella pagina Piattaforma Notifiche si visualizza il messaggio di errore codice IUN
     And Nella pagina Piattaforma Notifiche si controlla che il bottone Filtra sia attivo

--- a/src/test/resources/feature/2-mittente/2_ricercaNotifiche/009_ricercaPerCodiceIUN.feature
+++ b/src/test/resources/feature/2-mittente/2_ricercaNotifiche/009_ricercaPerCodiceIUN.feature
@@ -6,7 +6,7 @@ Feature: Mittente effetua una ricerca notifiche per codice IUN
   @ricercaNatoficheMittente
 
   Scenario: PN-9218 - Mittente loggato effettua una ricerca per codice IUN
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Si visualizza correttamente la pagina Piattaforma Notifiche
     And Nella pagina Piattaforma Notifiche si recupera un codice IUN valido
     And Cliccare sul bottone Filtra

--- a/src/test/resources/feature/2-mittente/2_ricercaNotifiche/010_ricercaPerCodiceData.feature
+++ b/src/test/resources/feature/2-mittente/2_ricercaNotifiche/010_ricercaPerCodiceData.feature
@@ -6,7 +6,7 @@ Feature: Mittente effetua una ricerca notifiche per Data
   @ricercaNatoficheMittente
 
   Scenario: PN-9220 - Mittente loggato effettua una ricerca per periodo temporale
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche inserire un arco temporale
     And Cliccare sul bottone Filtra
     Then Nella pagina Piattaforma Notifiche vengo restituite tutte le notifiche con la data della notifica compresa tra <da> e <a>

--- a/src/test/resources/feature/2-mittente/2_ricercaNotifiche/011_ricercaPerCodiceStato.feature
+++ b/src/test/resources/feature/2-mittente/2_ricercaNotifiche/011_ricercaPerCodiceStato.feature
@@ -6,7 +6,7 @@ Feature: Mittente effetua una ricerca notifiche per Stato
     @ricercaNatoficheMittente
 
   Scenario Outline: PN-9324 - Mittente logato effettua una ricerca per stato notifica
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina piattaforma Notifiche selezionare uno stato notifica <stato>
     And Cliccare sul bottone Filtra
     Then Nella pagina Piattaforma Notifiche vengo restituite tutte le notifiche con lo stato della notifica <stato>

--- a/src/test/resources/feature/2-mittente/2_ricercaNotifiche/012_1_ricercaCombinataCFPeriodoTemporale.feature
+++ b/src/test/resources/feature/2-mittente/2_ricercaNotifiche/012_1_ricercaCombinataCFPeriodoTemporale.feature
@@ -6,7 +6,7 @@ Feature: il mittente fa una ricerca combinata tra cf e periodo temporale
   @ricercaNatoficheMittente
 
   Scenario: PN-9222 - il mittente fa una ricera sia per cf che per periodo temporale
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche inserire il codice fiscale della persona fisica "personaFisica"
     And Nella pagina Piattaforma Notifiche inserire un arco temporale
     And Cliccare sul bottone Filtra

--- a/src/test/resources/feature/2-mittente/2_ricercaNotifiche/012_2_ricercaCombinataDataStato.feature
+++ b/src/test/resources/feature/2-mittente/2_ricercaNotifiche/012_2_ricercaCombinataDataStato.feature
@@ -6,7 +6,7 @@ Feature: il mittente fa una ricerca combinata tra stato e data
     @TA_MittenteRicercaPerDataStato
 
   Scenario Outline: PN-9222 - il mittente fa una ricerca sia per data che per stato
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche inserire una data
     And Nella pagina piattaforma Notifiche selezionare uno stato notifica <stato>
     And Cliccare sul bottone Filtra

--- a/src/test/resources/feature/2-mittente/2_ricercaNotifiche/012_3_ricercaCombinataStatoPeriodoTemporale.feature
+++ b/src/test/resources/feature/2-mittente/2_ricercaNotifiche/012_3_ricercaCombinataStatoPeriodoTemporale.feature
@@ -6,7 +6,7 @@ Feature: il mittente fa una ricerca combinata tra stato e arco temporale
     @TA_MittenteRicercaPerStatoPeriodo
 
   Scenario Outline: PN-9222 - il mittente fa una ricerca sia per arco temporale che per stato
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche inserire un arco temporale
     And Nella pagina piattaforma Notifiche selezionare uno stato notifica <stato>
     And Cliccare sul bottone Filtra

--- a/src/test/resources/feature/2-mittente/2_ricercaNotifiche/012_4_ricercaCombinataErrore.feature
+++ b/src/test/resources/feature/2-mittente/2_ricercaNotifiche/012_4_ricercaCombinataErrore.feature
@@ -6,7 +6,7 @@ Feature: il mittente fa una ricerca combinata tra stato e arco temporale  con ne
     @TA_MittenteRicercaSenaRisultatoPerStatoPeriodo
 
   Scenario Outline: PN-9325 - il mittente fa una ricerca sia per arco temporale che per stato con nessun risultato
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche inserire una data da <inizioArcoTemporale> a <fineArcoTemporale>
     And Nella pagina piattaforma Notifiche selezionare uno stato notifica <stato>
     And Cliccare sul bottone Filtra

--- a/src/test/resources/feature/2-mittente/2_ricercaNotifiche/012_5_ricercaCombinataCFData.feature
+++ b/src/test/resources/feature/2-mittente/2_ricercaNotifiche/012_5_ricercaCombinataCFData.feature
@@ -6,7 +6,7 @@ Feature: il mittente fa una ricerca combinata tra cf e data
   @TA_MittenteRicercaPerCFeData
 
   Scenario: PN-9222 - il mittente fa una ricera sia per cf che per data
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche inserire il codice fiscale della persona fisica "personaFisica"
     And Nella pagina Piattaforma Notifiche inserire una data
     And Cliccare sul bottone Filtra

--- a/src/test/resources/feature/2-mittente/2_ricercaNotifiche/012_ricercaCombinataCFStato.feature
+++ b/src/test/resources/feature/2-mittente/2_ricercaNotifiche/012_ricercaCombinataCFStato.feature
@@ -6,7 +6,7 @@ Feature: il mittente fa una ricerca combinata tra cf e stato
     @TA_MittenteRicercaPerCFeStato
 
   Scenario Outline: PN-9222 - il mittente fa una ricera sia per cf che per stato
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche inserire il codice fiscale della persona fisica "personaFisica"
     And Nella pagina piattaforma Notifiche selezionare uno stato notifica <stato>
     And Cliccare sul bottone Filtra

--- a/src/test/resources/feature/2-mittente/3_downloadFile/014_1_downloadFileDettaglioNotificaMittente.feature
+++ b/src/test/resources/feature/2-mittente/3_downloadFile/014_1_downloadFileDettaglioNotificaMittente.feature
@@ -6,7 +6,7 @@ Feature: Mittente scarica tutti i file all'interno di una notifica
   @DownloadFileMittente
 
   Scenario: PN-9327 - Mittente scarica attestazioni
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Creo in background una notifica con un destinatario e un documento tramite API REST
     Then Attendo 3 minuti e verifico in background che la notifica sia stata creata correttamente
     When Nella pagina Piattaforma Notifiche si clicca sulla notifica restituita

--- a/src/test/resources/feature/2-mittente/3_downloadFile/097_downloadAttestazioniNotificaPresaInCarico.feature
+++ b/src/test/resources/feature/2-mittente/3_downloadFile/097_downloadAttestazioniNotificaPresaInCarico.feature
@@ -6,7 +6,7 @@ Feature: il mittente download attestazione notifica presa in carico
   @DownloadFileMittente
 
   Scenario: il mittente scarica il file Attestazione opponibile a terzi: notifica presa in carico
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Cliccare sulla notifica restituita
     And Si visualizza correttamente la section Dettaglio Notifica
     And Nella sezione Dettaglio Notifiche si seleziona il file, "Attestazione opponibile a terzi: notifica presa in carico", da scaricare

--- a/src/test/resources/feature/2-mittente/3_downloadFile/098_downloadAttestazioneNotificaDigitale.feature
+++ b/src/test/resources/feature/2-mittente/3_downloadFile/098_downloadAttestazioneNotificaDigitale.feature
@@ -6,7 +6,7 @@ Feature: il mittente effettua il download attestazione opponibile a terzi notifi
   @DownloadFileMittente
 
   Scenario: il mittente effettua il download attestazione opponibile a terzi notifica digitale
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche si recupera un codice IUN di una persona giuridica
     And Cliccare sul bottone Filtra
     When Cliccare sulla notifica restituita

--- a/src/test/resources/feature/2-mittente/3_downloadFile/099_downloadAttestazioneAvvenutoSuccesso.feature
+++ b/src/test/resources/feature/2-mittente/3_downloadFile/099_downloadAttestazioneAvvenutoSuccesso.feature
@@ -6,7 +6,7 @@ Feature: il mittente effettua il download attestazione opponibile a terzi avvenu
   @DownloadFileMittente
 
   Scenario: PN-9647 - il mittente effettua il download attestazione opponibile a terzi avvenuto successo
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche inserire il codice fiscale della persona fisica "personaFisica"
     And Nella pagina piattaforma Notifiche selezionare lo stato notifica "Avvenuto accesso"
     And Cliccare sul bottone Filtra

--- a/src/test/resources/feature/2-mittente/3_downloadFile/100_downloadAttestazioniMancatoRecapitoDigitale.feature
+++ b/src/test/resources/feature/2-mittente/3_downloadFile/100_downloadAttestazioniMancatoRecapitoDigitale.feature
@@ -6,7 +6,7 @@ Feature: il mittente effettua il download attestazione opponibile a terzi mancat
   @DownloadFileMittente
 
   Scenario:il mittente effettua il download attestazione opponibile a terzi mancato recapito digitale
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche si verifica l'esistenza della notifica con il codice IUN
     And Nella pagina Piattaforma Notifiche inserire il codice IUN della notifica "datiNotifica"
     And Cliccare sul bottone Filtra

--- a/src/test/resources/feature/2-mittente/4_visualizzazioneNotifiche/007_visualizzazioneNotifiche.feature
+++ b/src/test/resources/feature/2-mittente/4_visualizzazioneNotifiche/007_visualizzazioneNotifiche.feature
@@ -6,7 +6,7 @@ Feature: Mittente visualizza correttamente la pagina notifiche
   @visualizzazioneNotificheMittente
 
   Scenario: PN-9216 - Mittente visualizza correttamente la pagina notifiche
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche visualizzano correttamente i filtri di ricerca
     Then Nella pagina Piattaforma Notifiche si visualizza correttamente l'elenco delle notifiche
     And Logout da portale mittente

--- a/src/test/resources/feature/2-mittente/4_visualizzazioneNotifiche/013_paginazionePiattaformaNotifiche.feature
+++ b/src/test/resources/feature/2-mittente/4_visualizzazioneNotifiche/013_paginazionePiattaformaNotifiche.feature
@@ -6,7 +6,7 @@ Feature:il mittente cambia visualizzazione della pagina
   @visualizzazioneNotificheMittente
 
   Scenario: PN-9223 - il mittente cambia visualizzazione della pagina
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche si visualizzano le notifiche a partire dalla più recente
     And Nella pagina Piattaforma Notifiche si scrolla fino alla fine della pagina
     And Nella pagina Piattaforma Notifiche si controlla che vengano visualizzate dieci notifiche

--- a/src/test/resources/feature/2-mittente/4_visualizzazioneNotifiche/014_dettaglioNotifica.feature
+++ b/src/test/resources/feature/2-mittente/4_visualizzazioneNotifiche/014_dettaglioNotifica.feature
@@ -6,7 +6,7 @@ Feature: Mittente visualizza il dettaglio di una notifica
   @visualizzazioneNotificheMittente
 
   Scenario: PN-9225 - Mittente visualizza dettaglio notifica
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche si recupera un codice IUN valido
     And Cliccare sul bottone Filtra
     When Nella pagina Piattaforma Notifiche si clicca sulla notifica restituita

--- a/src/test/resources/feature/2-mittente/5_apiKey/001_020_visualizzazioneApiKey.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/001_020_visualizzazioneApiKey.feature
@@ -6,7 +6,7 @@ Feature: Mittente visualizza correttamente la pagina Api Key
   @ApikeyMittente
 
   Scenario: PN-9228 - Mittente visualizza correttamente la pagina Api Key
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     And Si visualizza correttamente la lista delle Api Key generate

--- a/src/test/resources/feature/2-mittente/5_apiKey/002_021_visualizzazioneSezioneGeneraApiKeyPage.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/002_021_visualizzazioneSezioneGeneraApiKeyPage.feature
@@ -6,7 +6,7 @@ Feature: Mittente visualizza correttamente la sezione genera Api Key
   @ApikeyMittente
 
   Scenario: PN-9229 - Mittente visualizza correttamente la sezione genera Api Key
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     When Nella pagina Api Key si clicca sul bottone genera Api Key

--- a/src/test/resources/feature/2-mittente/5_apiKey/003_022_generaApiKeySenzaGruppo.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/003_022_generaApiKeySenzaGruppo.feature
@@ -6,7 +6,7 @@ Feature: Mittente genera Api Key senza gruppo
   @ApikeyMittente
 
   Scenario: PN-9230 - Mittente genera Api Key senza gruppo
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     When Nella pagina Api Key si clicca sul bottone genera Api Key

--- a/src/test/resources/feature/2-mittente/5_apiKey/004_023_generaApiKeyConGruppo.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/004_023_generaApiKeyConGruppo.feature
@@ -6,7 +6,7 @@ Feature: Mittente genera Api Key con gruppo
   @ApikeyMittente
 
   Scenario: PN-9231 - Mittente genera Api Key con gruppo
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     When Nella pagina Api Key si clicca sul bottone genera Api Key

--- a/src/test/resources/feature/2-mittente/5_apiKey/005_024_opzioneVisualizzaApiKey.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/005_024_opzioneVisualizzaApiKey.feature
@@ -6,7 +6,7 @@ Feature: Mittente seleziona l'opzione visualizza api Key
   @ApikeyMittente
 
   Scenario: PN-9232 - Mittente seleziona l'opzione visualizza api Key
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     When Nella pagina Api Key si clicca sul bottone menu di una Api Key attiva presente in elenco

--- a/src/test/resources/feature/2-mittente/5_apiKey/006_25_NEG2.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/006_25_NEG2.feature
@@ -6,7 +6,7 @@ Feature: Mittente seleziona CTA annulla in blocca api Key
   @ApikeyMittente
 
   Scenario: PN-9233 - Mittente seleziona CTA annulla in blocca api Key
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     When Nella pagina Api Key si clicca sul bottone menu di una Api Key attiva presente in elenco

--- a/src/test/resources/feature/2-mittente/5_apiKey/007_025_opzioneBloccaApiKey.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/007_025_opzioneBloccaApiKey.feature
@@ -6,7 +6,7 @@ Feature: Mittente seleziona l'opzione blocca api Key
   @ApikeyMittente
 
   Scenario: PN-9233 - Mittente seleziona l'opzione blocca Api Key
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     When Nella pagina Api Key si clicca sul bottone menu di una Api Key attiva presente in elenco

--- a/src/test/resources/feature/2-mittente/5_apiKey/008_26_NEG3.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/008_26_NEG3.feature
@@ -6,7 +6,7 @@ Feature: Mittente seleziona CTA annulla in attiva api Key
   @ApikeyMittente
 
   Scenario: PN-9234 - Mittente seleziona CTA annulla in attiva api Key
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     When Nella pagina Api Key si clicca sul bottone menu di una Api Key bloccata presente in elenco

--- a/src/test/resources/feature/2-mittente/5_apiKey/009_026_opzioneAttivaApiKey.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/009_026_opzioneAttivaApiKey.feature
@@ -7,7 +7,7 @@ Feature: Mittente seleziona l'opzione attiva api Key
   @ApikeyMittente
 
   Scenario: PN-9234 - Mittente seleziona l'opzione attiva Api Key
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     When Nella pagina Api Key si clicca sul bottone menu di una Api Key bloccata presente in elenco

--- a/src/test/resources/feature/2-mittente/5_apiKey/010_27_NEG4.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/010_27_NEG4.feature
@@ -6,7 +6,7 @@ Feature: Mittente seleziona CTA annulla in ruota api Key
   @ApikeyMittente
 
   Scenario: PN-9648 - Mittente seleziona CTA annulla in ruota api Key
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     When Nella pagina Api Key si clicca sul bottone menu di una Api Key attiva presente in elenco

--- a/src/test/resources/feature/2-mittente/5_apiKey/011_visualizzazioneIdGruppi.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/011_visualizzazioneIdGruppi.feature
@@ -6,7 +6,7 @@ Feature: Mittente seleziona l'opzione visualizza ID gruppo
   @ApikeyMittente
 
   Scenario: PN-9236 - Mittente seleziona l'opzione visualizza ID gruppo
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     When Nella pagina Api Key si clicca sul bottone menu di una Api Key attiva presente in elenco

--- a/src/test/resources/feature/2-mittente/5_apiKey/012_027_opzioneRuotaApiKey.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/012_027_opzioneRuotaApiKey.feature
@@ -6,7 +6,7 @@ Feature: Mittente seleziona l'opzione ruota api Key
   @ApikeyMittente
 
   Scenario: PN-9235 - Mittente seleziona l'opzione ruota Api Key
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     When Nella pagina Api Key si clicca sul bottone menu di una Api Key attiva presente in elenco

--- a/src/test/resources/feature/2-mittente/5_apiKey/013_22_NEG1.feature
+++ b/src/test/resources/feature/2-mittente/5_apiKey/013_22_NEG1.feature
@@ -6,7 +6,7 @@ Feature: Mittente genera Api Key senza inserire il nome dell api key
   @ApikeyMittente1
 
   Scenario: PN-9235 - Mittente genera Api Key senza inserire il nome dell api key
-    Given PA - Si effettua la login tramite token exchange di "mittente" e viene visualizzata la dashboard
+    Given PA - Si effettua la login tramite token exchange, e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche selezionare la voce Api Key nel menu
     And Si visualizza correttamente la pagina Api Key
     When Nella pagina Api Key si clicca sul bottone genera Api Key

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/001_031_NEG_inserimentoPECSbagliata.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/001_031_NEG_inserimentoPECSbagliata.feature
@@ -6,7 +6,7 @@ Feature: La persona fisica inserisce una PEC sbagliata
   @PF
 
   Scenario: PN-9240-B31 - La persona fisica inserisce una PEC sbagliata
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una pec

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/002_033_inserimentoOTPSbagliatoPec.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/002_033_inserimentoOTPSbagliatoPec.feature
@@ -6,7 +6,7 @@ Feature:La persona fisica inserisce una OTP sbagliato PEC
   @recapitiPF
 
   Scenario:La persona fisica loggato inserisce un OTP sbagliato PEC
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una pec

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/003_031_inserimentoIndirizzoPEC.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/003_031_inserimentoIndirizzoPEC.feature
@@ -4,9 +4,9 @@ Feature: la persona fisica inserisce una email pec
   @TA_inserimentoPECPF
   @PF
   @recapitiPF
-    
+
   Scenario: PN-9240-A31 - La persona fisica inserisce una email pec
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una pec

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/004_032_modificaIndirizzoPEC.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/004_032_modificaIndirizzoPEC.feature
@@ -6,7 +6,7 @@ Feature: la persona fisica modifica l'indirizzo pec già presente
   @recapitiPF
 
   Scenario: PN-9306-D32 - la persona fisica modifica l'indirizzo pec già presente
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti di PF, si controlla che ci sia già una pec

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/005_034_NEG1_inserimentoOTPEmailSbagliato.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/005_034_NEG1_inserimentoOTPEmailSbagliato.feature
@@ -6,7 +6,7 @@ Feature: la persona fisica inserisce un OTP email sbagliato
   @recapitiPF
 
   Scenario: PN-9308-E34 - la persona fisica inserisce un OTP email sbagliato
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una email

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/006_034_NEG_inserimentoEmailSbagliata.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/006_034_NEG_inserimentoEmailSbagliata.feature
@@ -6,7 +6,7 @@ Feature: La persona fisica inserisce una email sbagliata
   @recapitiPF
 
   Scenario: PN-9308-B34 - La persona fisica inserisce una email sbagliata
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una email

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/007_034_inserimentoIndirizzoEmail.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/007_034_inserimentoIndirizzoEmail.feature
@@ -6,7 +6,7 @@ Feature: la persona fisica inserisce una Email
   @PF
 
   Scenario: PN-9308-A34 - la persona fisica inserisce una Email
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una email

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/008_035_modificaIndirizzoEmail.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/008_035_modificaIndirizzoEmail.feature
@@ -6,7 +6,7 @@ Feature: la persona fisica modifica l'indirizzo Email
   @recapitiPF
 
   Scenario: PN-9309 - la persona fisica modifica l'indirizzo Email
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti si controlla che ci sia già una Email

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/009_037_NEG1_inserimentoOTPNumeroDiTelefonoSbagliato.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/009_037_NEG1_inserimentoOTPNumeroDiTelefonoSbagliato.feature
@@ -6,7 +6,7 @@ Feature: la persona fisica inserisce l'OTP numero di telefono  errato
   @recapitiPF
 
   Scenario: PN-9311-C37 - la persona fisica inserisce l'OTP numero di telefono errato
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti si inserisce il numero di telefono del PF "personaFisica" e clicca sul bottone avvisami via SMS

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/010_037_NEG_inserimentoNumeroDiTelefonoSbagliato.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/010_037_NEG_inserimentoNumeroDiTelefonoSbagliato.feature
@@ -5,7 +5,7 @@ Feature: la persona fisica inserisce un numero di telefono errato
   @PF
   @recapitiPF
   Scenario: PN-9311-B37 - La persona fisica inserisce un numero di telefono errato
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti si inserisce il numero di telefono errato "2318773225"

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/012_040_1_inserimentoIndirizzoEmailAggiuntivo.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/012_040_1_inserimentoIndirizzoEmailAggiuntivo.feature
@@ -6,7 +6,7 @@ Feature: la persona fisica inserisce un indirizzo Email aggiuntivo
   @recapitiPF
 
   Scenario: PN-9318-I40 - la persona fisica inserisce un indirizzo Email aggiuntivo
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti si controlla che ci sia già una Email diversa

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/013_040_inserimentoIndirizzoPECAggiuntivo.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/013_040_inserimentoIndirizzoPECAggiuntivo.feature
@@ -6,7 +6,7 @@ Feature: la persona fisica inserisce un indirizzo pec aggiuntivo
   @PF
 
   Scenario: PN-9318-D40 - la persona fisica inserisce un indirizzo pec aggiuntivo
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti si controlla che ci sia già la nuova pec

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/014_041_visualizzazioneAltriRecapiti.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/014_041_visualizzazioneAltriRecapiti.feature
@@ -6,7 +6,7 @@ Feature: la persona fisica visualizza correttamente la sezione altri recapiti
   @recapitiPF
 
   Scenario: PN-9318-A40 - La persona fisica visualizza correttamente la sezione altri recapiti
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And si verifica esistenza due pec

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/015_033_eliminaIndirizzoPEC.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/015_033_eliminaIndirizzoPEC.feature
@@ -6,7 +6,7 @@ Feature: la persona fisica elimina l'indirizzo pec
   @recapitiPF
 
   Scenario: PN-9307 - la persona fisica elimina l'indirizzo pec
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti di PF, si controlla che ci sia già una pec

--- a/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/016_036_eliminaIndirizzoEmail.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/altriRecapiti/016_036_eliminaIndirizzoEmail.feature
@@ -6,7 +6,7 @@ Feature: la persona fisica elimina l'indirizzo Email
   @PF
 
   Scenario: PN-9310-A36 - la persona fisica elimina l'indirizzo Email
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina I Tuoi Recapiti
     And Nella pagina I Tuoi Recapiti si controlla che ci sia già una Email

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/001_044_aggiuntaNuovaDelega.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/001_044_aggiuntaNuovaDelega.feature
@@ -6,7 +6,7 @@ Feature:La persona fisica aggiunge una nuova delega
   @PF
 
   Scenario:PN-9401 - La persona fisica aggiunge una nuova delega
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica click sul bottone Deleghe
     And Nella pagina Piattaforma Notifiche persona fisica si vede la sezione Deleghe
     And Si controlla che non sia presente una delega con stesso nome "nuova_delega"

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/002_045_visualizzaElencoDeleghe.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/002_045_visualizzaElencoDeleghe.feature
@@ -6,7 +6,7 @@ Feature:La persona fisica visualizza la sezione aggiungi una nuova delega
   @PF
 
   Scenario:PN-9399 - La persona fisica visualizza la sezione aggiungi una nuova delega
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica click sul bottone Deleghe
     And Nella pagina Piattaforma Notifiche persona fisica si vede la sezione Deleghe
     And Nella sezione Deleghe si verifica sia presente una delega

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/003_046_visualizzaCodiceDelega.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/003_046_visualizzaCodiceDelega.feature
@@ -4,9 +4,9 @@ Feature:La persona fisica visualizza il codice  di una delega
   @TA_PFvisualizzaCodiceDelega
   @DeleghePF
   @PF
-    
+
   Scenario:PN-9402 - La persona fisica visualizza il codice  di una delega
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica click sul bottone Deleghe
     And Nella pagina Piattaforma Notifiche persona fisica si vede la sezione Deleghe
     And Nella sezione Deleghe si verifica sia presente una delega "nuova_delega"

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/004_053_aggiuntaNuovaDelegaGiaPresente.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/004_053_aggiuntaNuovaDelegaGiaPresente.feature
@@ -6,7 +6,7 @@ Feature: persona fisica aggiunge una delega allo stesso delegato
   @PF
 
   Scenario:PN-9431 - La persona fisica aggiunge una delega allo stesso delegato
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica click sul bottone Deleghe
     And Nella pagina Piattaforma Notifiche persona fisica si vede la sezione Deleghe
     And Nella sezione Deleghe si verifica sia presente una delega "nuova_delega"

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/005_048_accetazioneDelega.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/005_048_accetazioneDelega.feature
@@ -6,7 +6,7 @@ Feature: il delegato accetta la delega
   @PF
 
   Scenario: PN-9411 - il delegato accetta la delega
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica click sul bottone Deleghe
     And Si verifica sia presente una delega nella sezione Deleghe a Tuo Carico "personaFisica"
     And si sceglie opzione accetta

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/006_050_visualizzazioneNotificheDelegante.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/006_050_visualizzazioneNotificheDelegante.feature
@@ -1,12 +1,12 @@
 Feature: Il delegato visualizza la notifiche del delegante
-  
+
   @TestSuite
   @TA_PFvisualizzaNotificheDelegante
   @DeleghePF
   @PF
 
   Scenario: PN-9419 - Il delegato visualizza la notifiche del delegante
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche persona fisica click sul bottone Deleghe
     And Nella pagina Piattaforma Notifiche persona fisica si vede la sezione Deleghe
     And Nella sezione Deleghe si verifica sia presente una delega accettata

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/007_051_visualizzaDettaglioNotifica.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/007_051_visualizzaDettaglioNotifica.feature
@@ -6,7 +6,7 @@ Feature: Il delegato visualizza il dettaglio di una notifica
   @PF
 
   Scenario:PN-9417 - Il delegato visualizza il dettaglio di una notifica
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche persona fisica click sul bottone Deleghe
     And Nella pagina Piattaforma Notifiche persona fisica si vede la sezione Deleghe
     And Nella sezione Deleghe si verifica sia presente una delega accettata

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/008_47_NEG_anullamentoRifutoDelega.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/008_47_NEG_anullamentoRifutoDelega.feature
@@ -6,7 +6,7 @@ Feature: Il delegato persona fisica annulLa l'operazione di rifiuto delega
   @PF
 
   Scenario: Il delegato persona fisica annulLa l'operazione di rifiuto delega
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica click sul bottone Deleghe
     And Si verifica sia presente una delega nella sezione Deleghe a Tuo Carico "personaFisica"
     And Nella pagina Deleghe si clicca sul menu della delega a tuo carico "personaFisica"

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/009_rifiutoDelega.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/009_rifiutoDelega.feature
@@ -6,7 +6,7 @@ Feature: Il delgato persona fisica rifiuta la delega che gli è stata inviata
   @PF
 
   Scenario: PN-9414 - Il delegato persona fisica rifiuta la delega che gli è stata inviata
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica click sul bottone Deleghe
     And Si verifica sia presente una delega da rifiutare nella sezione Deleghe a Tuo Carico "personaFisica"
     And Nella pagina Deleghe si clicca sul menu della delega a tuo carico "personaFisica"

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/010_047_revocaDeleghe.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/010_047_revocaDeleghe.feature
@@ -6,7 +6,7 @@ Feature:La persona fisica revoca una delega
   @PF
 
   Scenario:PN-9403 - La persona fisica revoca una delega
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica click sul bottone Deleghe
     And Nella pagina Piattaforma Notifiche persona fisica si vede la sezione Deleghe
     And Nella sezione Deleghe si verifica sia presente una delega "nuova_delega"

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/011_052_aggiuntaDelegaSeStessi.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghePF/011_052_aggiuntaDelegaSeStessi.feature
@@ -6,7 +6,7 @@ Feature:La persona fisica aggiunge una delega a se stessi
   @PF
 
   Scenario:PN-9420 - La persona fisica aggiunge una delega a se stessi
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica click sul bottone Deleghe
     And Nella pagina Piattaforma Notifiche persona fisica si vede la sezione Deleghe
     And Nella sezione Deleghe click sul bottone aggiungi nuova delega

--- a/src/test/resources/feature/3-destinatario/personaFisica/downloadFile/019_downloadAttestazioni.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/downloadFile/019_downloadAttestazioni.feature
@@ -6,7 +6,7 @@ Feature: persona fisica scarica attestazioni all'interno di una notifica
   @PF
 
   Scenario: PN-9239 - persona fisica scarica attestazione
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     And Nella pagina Piattaforma Notifiche PF si recupera un codice IUN valido
     And Cliccare sul bottone Filtra persona fisica
     When La persona fisica clicca sulla notifica restituita

--- a/src/test/resources/feature/3-destinatario/personaFisica/ricercaNotifica/018_ricercaPerData.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/ricercaNotifica/018_ricercaPerData.feature
@@ -6,7 +6,7 @@ Feature: Ricerca notifica per periodo temporale persona fisica
   @PFRicercaNotifica
 
   Scenario: PN-9224 - La persona fisica fa una ricerca per date
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Si visualizza correttamente la pagina Piattaforma Notifiche persona fisica
     And Nella pagina Piattaforma Notifiche persona fisica inserire un arco temporale
     And Cliccare sul bottone Filtra persona fisica

--- a/src/test/resources/feature/3-destinatario/personaFisica/visualizzaNotifiche/015_visualizzazioneNotifiche.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/visualizzaNotifiche/015_visualizzazioneNotifiche.feature
@@ -6,7 +6,7 @@ Feature: La persona fisica visualizza la sezione notifiche
   @PF
 
   Scenario:PN-9184 - La persona fisica visualizza la sezione notifiche
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona fisica si clicca sul bottone Notifiche
     And Si visualizza correttamente la Pagina Notifiche persona fisica
     And Nella Pagina Notifiche persona fisica si visualizzano correttamente i filtri di ricerca

--- a/src/test/resources/feature/3-destinatario/personaFisica/visualizzaNotifiche/016_sezioneNotifichePaginazione.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/visualizzaNotifiche/016_sezioneNotifichePaginazione.feature
@@ -1,12 +1,12 @@
 Feature:La persona fisica visualizza le notifiche in elenco
-  
+
   @TestSuite
   @TA_PFPaginazioneNotifiche
   @PFvisualizzaNotifiche
   @PF
 
   Scenario:PN-9209 - La persona fisica visualizza le notifiche in elenco
-    Given PF - Si effettua la login tramite token exchange di "personaFisica" e viene visualizzata la dashboard
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Si visualizza correttamente la pagina Piattaforma Notifiche persona fisica
     Then Si visualizzano correttamente le notifiche in elenco paginato
     And Si visualizzano le notifiche dalla piu recente

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/001_061_neg1_inserimentoOTPSbagliatoPECPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/001_061_neg1_inserimentoOTPSbagliatoPECPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica inserisce una OTP sbagliato PEC
   @TA_inserimentoOTPErratoPG
 
   Scenario: PN-9152-D60 - La persona giuridica loggato inserisce un OTP sbagliato PEC
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina Recapiti persona giuridica
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una pec

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/002_061_neg_inserimentoPECSbagliataPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/002_061_neg_inserimentoPECSbagliataPG.feature
@@ -4,9 +4,9 @@ Feature: La persona giuridica inserisce una PEC
   @PG
   @recapitiPG
   @TA_inserimentoPECErrataPG
-    
+
   Scenario: PN-9152-B60 - La persona giuridica loggato inserisce una PEC
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina Recapiti persona giuridica
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una pec

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/003_061_inserimentoPECPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/003_061_inserimentoPECPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica inserisce una PEC
   @recapitiPG
 
   Scenario: PN-9152 - La persona giuridica inserisce una PEC
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina Recapiti persona giuridica
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una pec

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/004_062_modificaPECPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/004_062_modificaPECPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica modifica l'indirizzo PEC
   @recapitiPG
 
   Scenario: PN-9153 - La persona giuridica modifica l'indirizzo PEC
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina Recapiti persona giuridica
     And Nella pagina I Tuoi Recapiti PG si controlla che ci sia già una pec

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/005_064_NEG1_inserimentoOTPSbagliatoEmailPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/005_064_NEG1_inserimentoOTPSbagliatoEmailPG.feature
@@ -6,7 +6,7 @@ Feature: la persona giuridica inserisce un OTP email sbagliato
   @recapitiPG
 
   Scenario: PN-9155-D63 - La persona giuridica inserisce un OTP email sbagliato
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina Recapiti persona giuridica
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una email

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/006_064_NEG_inserimentoEmailSbagliataPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/006_064_NEG_inserimentoEmailSbagliataPG.feature
@@ -6,7 +6,7 @@ Feature: la persona giuridica inserisce una email errata
   @recapitiPG
 
   Scenario: PN-9155-B63 - La persona giuridica inserisce una email errata
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina Recapiti persona giuridica
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una email

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/007_065_inserimentoEmailPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/007_065_inserimentoEmailPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica inserisce l'email
   @recapitiPG
 
   Scenario: PN-9155 - La persona giuridica inserisce l'email
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina Recapiti persona giuridica
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una email

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/008_071_visualizzazioneAltriRecapitiPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/008_071_visualizzazioneAltriRecapitiPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica visualizza tutti gli elementi della sezione altri 
   @recapitiPG
 
   Scenario: PN-9162 - La persona giuridica visualizza tutti gli elementi della sezione altri recapiti
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina Recapiti persona giuridica
     And Nella pagina I Tuoi Recapiti si controlla che non ci sia già una pec

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/009_067_NEG1_inserimentoOTPSbagliatoNumeroDiTelefonoPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/009_067_NEG1_inserimentoOTPSbagliatoNumeroDiTelefonoPG.feature
@@ -6,7 +6,7 @@ Feature: la persona giuridica inserisce l'OTP numero di telefono  errato
   @recapitiPG
 
   Scenario: PN-9158-A66 - La persona giuridica inserisce l'OTP numero di telefono errato
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina Recapiti persona giuridica
     And Nella pagina I Tuoi Recapiti si inserisce il numero di telefono del PG "personaGiuridica" e clicca sul bottone avvisami via SMS

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/010_067_NEG_inserimentoNumeroDiTelefonoSbagliatoPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/010_067_NEG_inserimentoNumeroDiTelefonoSbagliatoPG.feature
@@ -6,7 +6,7 @@ Feature: la persona giuridica inserisce un numero di telefono errato
   @recapitiPG
 
   Scenario: PN-9158-A66 - La persona giuridica inserisce un numero di telefono errato
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina Recapiti persona giuridica
     And Nella pagina I Tuoi Recapiti si inserisce il numero di telefono errato "2318773225"

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/011_063_eliminaPECPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/011_063_eliminaPECPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica elimina l'indirizzo PEC
   @recapitiPG
 
   Scenario: PN-9154 - La persona giuridica elimina l'indirizzo PEC
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina Recapiti persona giuridica
     And Nella pagina I Tuoi Recapiti di PG, si controlla che ci sia già una pec

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/012_066_eliminaEmailPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/altriRecapitiPG/012_066_eliminaEmailPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica elimina l'indirizzo email
   @recapitiPG
 
   Scenario: PN-9157 - La persona giuridica elimina l'indirizzo email
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica si clicca sul bottone I Tuoi Recapiti
     And Si visualizza correttamente la pagina Recapiti persona giuridica
     And Nella pagina I Tuoi Recapiti si controlla che ci sia già una Email

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/001_113_aggiuntaNuovaDelegaPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/001_113_aggiuntaNuovaDelegaPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica aggiunge una nuova delega
   @PG
 
   Scenario: PN-9165 - La persona giuridica aggiunge una nuova delega
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa
     And Nella pagina Deleghe si clicca su Delegati dall impresa

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/002_113_neg_aggiuntaDelegaErrorePG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/002_113_neg_aggiuntaDelegaErrorePG.feature
@@ -4,9 +4,9 @@ Feature: La persona giuridica aggiunge una nuova delga inserendo una data errata
   @TA_PGNuovaDelegaDataErrata
   @DeleghePG
   @PG
-    
+
   Scenario: PN-9165-A111 - La persona giuridica aggiunge una nuova delga inserendo una data errata
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa
     And Nella pagina Deleghe si clicca su Delegati dall impresa

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/003_114_visualizzaDelegheNonAssegnataGruppoPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/003_114_visualizzaDelegheNonAssegnataGruppoPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica visualizza le deleghe
 #  @DeleghePG
 #  @PG
   Scenario: PN-9166 - La persona giuridica visualizza le deleghe
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa
     And Nella pagina Deleghe si clicca su Delegati dall impresa

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/004_119_accettazioneDelegaSenzaGruppo.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/004_119_accettazioneDelegaSenzaGruppo.feature
@@ -7,7 +7,7 @@ Feature:Il delegato persona giuridica accetta la delega non assegnandoli un grup
 #  @PG
 
   Scenario: PN-9171 - Il delegato persona giuridica accetta la delega non assegnandoli un gruppo
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa
     And Nella sezione Deleghe si verifica sia presente una delega per PG "personaGiuridica"

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/005_116_visualizzaCodiceDelegaPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/005_116_visualizzaCodiceDelegaPG.feature
@@ -6,7 +6,7 @@ Feature:La persona giuridica visualizza il codice di una delega
   @PG
 
   Scenario: PN-9168 - La persona giuridica visualizza il codice di una delega
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa
     And Nella pagina Deleghe si clicca su Delegati dall impresa

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/006_aggiuntaNuovaDelegaPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/006_aggiuntaNuovaDelegaPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica aggiunge una nuova delega
   @PG
 
   Scenario: PN-9165 - La persona giuridica aggiunge una nuova delega
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     And Si visualizza correttamente la Pagina Notifiche persona giuridica "personaGiuridica_1"
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/007_118_accettazioneDelegaConGruppo.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/007_118_accettazioneDelegaConGruppo.feature
@@ -7,7 +7,7 @@ Feature:Il delegato persona giuridica accetta la delega assegnandoli un gruppo
 #  @PG
 
   Scenario: PN-9170 - Il delegato persona giuridica accetta la delega assegnandoli un gruppo
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa
     And Nella sezione Deleghe si verifica sia presente una delega

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/008_115_ricercaDelegheConGruppoPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/008_115_ricercaDelegheConGruppoPG.feature
@@ -8,7 +8,7 @@ Feature:La persona giuridica fa una ricerca per gruppo delle deleghe
 
 
   Scenario: PN-9167 - La persona giuridica fa una ricerca per gruppo delle deleghe
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa
     And Nella pagina Deleghe si clicca su Deleghe a carico dell impresa

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/009_114_1_ricercaDelegheSenzaGruppoPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/009_114_1_ricercaDelegheSenzaGruppoPG.feature
@@ -7,7 +7,7 @@ Feature:La persona giuridica visualizza le deleghe
 #  @PG
 
   Scenario: PN-9166 - La persona giuridica fa una ricerca delle deleghe
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa
     And Nella sezione Deleghe si verifica sia presente una delega accettata per PG "personaGiuridica"

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/011_121_1_modificaDelegaSenzaGruppo.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/011_121_1_modificaDelegaSenzaGruppo.feature
@@ -7,7 +7,7 @@ Feature: Il delegato persona giuridica modifica una delega non assegnandoli un g
 #  @PG
 
   Scenario: PN-9173 - Il delegato persona giuridica modifica una delega non assegnandoli un gruppo
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa
     And Nella sezione Deleghe si verifica sia presente una delega

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/011_121_modificaDelegaConGruppo.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/011_121_modificaDelegaConGruppo.feature
@@ -7,7 +7,7 @@ Feature: Il delegato persona giuridica modifica una delega assegnandoli un grupp
 #  @PG
 
   Scenario: PN-9173 - Il delegato persona giuridica modifica una delega assegnandoli un gruppo
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     And Nella sezione Deleghe si verifica sia presente una delega accettata per PG "personaGiuridica"
     And Nella pagina Deleghe sezione Deleghe a carico dell'impresa clicca sul menu della delega "personaGiuridica"
     And Nella sezione Deleghe si clicca sul bottone modifica

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/012_117_NEG_annullamentoRevocaDelega.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/012_117_NEG_annullamentoRevocaDelega.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica annulla l'operazione di revoca una delega
   @PG
 
   Scenario: PN-9169-A115 - La persona giuridica annulla l'operazione di revoca una delega
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     And Si visualizza correttamente la Pagina Notifiche persona giuridica "personaGiuridica_1"
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/013_117_revocaDelegaPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/013_117_revocaDelegaPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica revoca una delega
   @PG
 
   Scenario: PN-9169 - La persona giuridica revoca una delega
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     And Si visualizza correttamente la Pagina Notifiche persona giuridica "personaGiuridica_1"
     And Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/014_120_NEG_annullamentoRifiutoDelegaPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/014_120_NEG_annullamentoRifiutoDelegaPG.feature
@@ -7,7 +7,7 @@ Feature:Il delegato persona giuridica annulLa l'operazione di rifiuto delega
 #  @PG
 
   Scenario: PN-9172-A118 - Il delegato persona giuridica annulLa l'operazione di rifiuto delega
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa
     And Nella sezione Deleghe si verifica sia presente una delega accettata per PG "personaGiuridica"

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/015_120_rifiutoDelegaPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/015_120_rifiutoDelegaPG.feature
@@ -7,7 +7,7 @@ Feature:Il delegato persona giuridica rifiuta la delega
 #  @PG
 
   Scenario: PN-9172 - Il delegato persona giuridica rifiuta la delega
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa
     And Nella sezione Deleghe si verifica sia presente una delega accettata per PG "personaGiuridica"

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/disserviziAppPG/01_72_visualizzazioneDisserviziPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/disserviziAppPG/01_72_visualizzazioneDisserviziPG.feature
@@ -5,7 +5,7 @@ Feature: La persona giuridica visualizza i disservizi della applicazione
   @TA_PG_VisualizzaDisservizio
 
   Scenario: PN-9163 - Il persona giuridica loggato visualizza lo stato dei disservizi
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     And Nella dashboard persona giuridica clicca su disservizi app
     And Si visualizza correttamente la Pagina dello Stato della piattaforma
     And Si visualizzano correttamente i dati sullo stato della piattaforma

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/downloadFilePG/060_downloadFilePG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/downloadFilePG/060_downloadFilePG.feature
@@ -4,9 +4,9 @@ Feature: persona giuridica scarica attestazioni all'interno di una notifica
   @TA_PG_DownloadFile
   @DownloadFilePG
   @PG
-    
+
   Scenario: PN-9151 - Persona giuridica scarica attestazione
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     And Nella Pagina Notifiche persona giuridica si clicca su notifiche dell impresa
     And Nella pagina Piattaforma Notifiche  persona giuridica inserire il codice IUN da dati notifica "datiNotificaPG"
     And Cliccare sul bottone Filtra persona fisica

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/ricercaNotifichePG/058_ricercaPerCodiceIUNPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/ricercaNotifichePG/058_ricercaPerCodiceIUNPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica ricerca per codice IUN
   @PG
 
   Scenario: PN-9149 - La persona giuridica ricerca per codice IUN
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     And Nella Pagina Notifiche persona giuridica si clicca su notifiche dell impresa
     And Nella pagina Piattaforma Notifiche  persona giuridica inserire il codice IUN da dati notifica "datiNotificaPG"
     And Cliccare sul bottone Filtra persona giuridica

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/ricercaNotifichePG/059_ricercaPerDataPG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/ricercaNotifichePG/059_ricercaPerDataPG.feature
@@ -6,7 +6,7 @@ Feature: La persona giuridica ricerca per periodo temporale
   @PG
 
   Scenario: PN-9150 - La persona giuridica ricerca per periodo temporale
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     And Nella Pagina Notifiche persona giuridica si clicca su notifiche dell impresa
     And Nella pagina Piattaforma Notifiche persona giuridica inserire un arco temporale
     And Cliccare sul bottone Filtra persona giuridica

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/visualizzazioneNotificaPG/056_visualizzazioneNotifichePG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/visualizzazioneNotificaPG/056_visualizzazioneNotifichePG.feature
@@ -7,7 +7,7 @@ Feature: La persona fisica visualizza la sezione notifiche
 #  @PG
 
   Scenario: PN-9147 - La persona giuridica visualizza la sezione notifiche
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
     And Nella Pagina Notifiche persona giuridica si clicca su notifiche dell impresa
     And Nella sezione Deleghe si verifica sia presente una delega accettata per PG "personaGiuridica"

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/visualizzazioneNotificaPG/057_paginazioneNotifichePG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/visualizzazioneNotificaPG/057_paginazioneNotifichePG.feature
@@ -6,7 +6,7 @@ Feature: La persona fisica visualizza la sezione notifiche
   @PG
 
   Scenario: PN-9148 - La persona giuridica visualizza la sezione notifiche
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     And Nella Pagina Notifiche persona giuridica si clicca su notifiche dell impresa
     And Si visualizzano le notifiche dalla piu recente
     And Si Controlla la paginazione di default

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/visualizzazioneNotificaPG/058_visualizzazioneDettaglioNotifica.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/visualizzazioneNotificaPG/058_visualizzazioneDettaglioNotifica.feature
@@ -7,7 +7,7 @@ Feature: La persona giuridica visualizza il dettaglio della notifica
 #  @PG
 
   Scenario: PN-9151 - La persona giuridica visualizza il dettaglio della notifica
-    Given PG - Si effettua la login tramite token exchange di "personaGiuridica" e viene visualizzata la dashboard
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
     When Nella Pagina Notifiche persona giuridica si clicca su notifiche dell impresa
     And Nella Pagina Notifiche persona giuridica si clicca su notifica
     And Nella sezione Dettaglio Notifiche si visualizza opzione indietro, sezione dei dati, sezione pagamento

--- a/src/test/resources/test-config.properties
+++ b/src/test/resources/test-config.properties
@@ -3,4 +3,4 @@ browser=chrome
 environment=test
 cookie.config=true
 headless=true
-loadComponentWaitTime=90
+loadComponentWaitTime=120


### PR DESCRIPTION
Issue Description
Currently, all tests for the various portals have a login procedure (via token exchange) in a single step. The step locally works perfectly, while it continues to fail on AWS servers.

This issue has been analyzed through this ticket: [PN-9840: [E2E] Fix pipeline-PG](https://pagopa.atlassian.net/browse/PN-9840)

Changes Made:
- removed unused feature steps
- added new feature steps into PA,PF & PG for the login through `tokenExchange`

How to Test
Simply run any test and verify if all the described logic has been correctly implemented.
Also a run into AWS CodeBuild is necessary in order to test the full feature.