### PR TITLE
PN-9171-accettazione-delega-non-aggiunta-ad-un-gruppo

### DIFF
--- a/src/main/java/it/pn/frontend/e2e/pages/destinatario/personaGiuridica/DeleghePGPagoPAPage.java
+++ b/src/main/java/it/pn/frontend/e2e/pages/destinatario/personaGiuridica/DeleghePGPagoPAPage.java
@@ -335,7 +335,7 @@ public class DeleghePGPagoPAPage extends BasePage {
     public void checkAlertWrongDelegationCode() {
         try {
             By alertWrongCode = By.id("alert-api-status}");
-            By alertCloseButtonBy = By.xpath("//*[@aria-label='Close']");
+            By alertCloseButtonBy = By.xpath("//button[@aria-label='Close']");
             this.getWebDriverWait(10).withMessage("Alert non visualizzato correttamente").until(ExpectedConditions.visibilityOfElementLocated(alertWrongCode));
             logger.info("Alert visualizzato correttamente in pagina");
             WebElement alertCloseButton = driver.findElement(alertCloseButtonBy);
@@ -350,7 +350,7 @@ public class DeleghePGPagoPAPage extends BasePage {
     public void clickButtonIndietroDaAssegnaGruppo() {
         try {
             logger.info("Si clicca sul bottone indietro per tornare al pop-up di inserimento codice delega");
-            By buttonIndietroPopUpAssegnaGruppo = By.xpath("//*[@data-testid='groupCancelButton']");
+            By buttonIndietroPopUpAssegnaGruppo = By.xpath("//button[@data-testid='groupCancelButton']");
             this.getWebDriverWait(10).until(ExpectedConditions.visibilityOfElementLocated(buttonIndietroPopUpAssegnaGruppo));
             WebElement buttonIndietroClick = driver.findElement(buttonIndietroPopUpAssegnaGruppo);
             buttonIndietroClick.click();
@@ -375,7 +375,7 @@ public class DeleghePGPagoPAPage extends BasePage {
             }
         }
         if (isInvalid) {
-            logger.info("Textbox di input codice delega sono in stato invalido");
+            logger.info("Textbox di input codice delega invalido");
         } else {
             logger.error("Almeno una textbox di input codice delega non in stato invalido");
             Assert.fail("Almeno una textbox di input codice delega non in stato invalido");

--- a/src/main/java/it/pn/frontend/e2e/pages/destinatario/personaGiuridica/DeleghePGPagoPAPage.java
+++ b/src/main/java/it/pn/frontend/e2e/pages/destinatario/personaGiuridica/DeleghePGPagoPAPage.java
@@ -109,7 +109,7 @@ public class DeleghePGPagoPAPage extends BasePage {
         try {
             this.getWebDriverWait(30).withMessage("delega non trovata").until(ExpectedConditions.visibilityOfElementLocated(delegaExist));
             return true;
-        }catch (TimeoutException e){
+        } catch (TimeoutException e) {
             return false;
         }
 
@@ -196,23 +196,23 @@ public class DeleghePGPagoPAPage extends BasePage {
     }
 
     public void clickBottoneConferma() {
-        getWebDriverWait(40).withMessage("Il bottone conferma nel pop up di scelta gruppo non è cliccabile").until(ExpectedConditions.elementToBeClickable(this.confermaButton));
+        getWebDriverWait(10).withMessage("Il bottone conferma nel pop up di scelta gruppo non è cliccabile").until(ExpectedConditions.elementToBeClickable(this.confermaButton));
         this.confermaButton.click();
     }
 
-    public void clickBottoneConfermaDelega(){
+    public void clickBottoneConfermaDelega() {
         getWebDriverWait(20).withMessage("il bottone conferma delega pg non é visibile").until(ExpectedConditions.elementToBeClickable(confermaAccettazioneDelegaButton));
         confermaAccettazioneDelegaButton.click();
     }
 
     public boolean verificaEsistenzaErroreCodiceSbagliato() {
         try {
-            By esistenzaBy = By.id("alert-api-status");
-            this.getWebDriverWait(30).until(ExpectedConditions.visibilityOfElementLocated(esistenzaBy));
+            By esistenzaBy = By.id("alert-api-status}");
+            this.getWebDriverWait(5).until(ExpectedConditions.visibilityOfElementLocated(esistenzaBy));
             logger.info("Errore codice sbagliato trovato");
             return true;
         } catch (TimeoutException e) {
-            logger.info("errore non trovato");
+            logger.info("Errore non trovato");
             return false;
         }
 
@@ -296,19 +296,19 @@ public class DeleghePGPagoPAPage extends BasePage {
         this.groupOption.click();
     }
 
-    public String getCodiceVerificaDelegaACaricoDellImpresaAPI(){
-        try{
+    public String getCodiceVerificaDelegaACaricoDellImpresaAPI() {
+        try {
             String pathIniziale = System.getProperty("user.dir");
             String text = Files.readString(Paths.get(pathIniziale + "/src/test/resources/dataPopulation/bodyChiamataDeleghe.json"));
             JSONObject object = new JSONObject(text);
             return object.getString("verificationCode");
-        }catch (IOException e) {
+        } catch (IOException e) {
             logger.error("non é stato possibile reperire il codice di verifica dal json");
             throw new RuntimeException(e);
         }
     }
 
-    public void inserimentoCodiceDelegaACaricoDellImpresaAPI(String codiceDelega){
+    public void inserimentoCodiceDelegaACaricoDellImpresaAPI(String codiceDelega) {
         String[] codiciDelega = codiceDelega.split("");
         for (int i = 0; i < 5; i++) {
             String xpathBy = "code-input-" + i;
@@ -332,6 +332,56 @@ public class DeleghePGPagoPAPage extends BasePage {
         }
     }
 
+    public void checkAlertWrongDelegationCode() {
+        try {
+            By alertWrongCode = By.id("alert-api-status}");
+            By alertCloseButtonBy = By.xpath("//*[@aria-label='Close']");
+            this.getWebDriverWait(10).withMessage("Alert non visualizzato correttamente").until(ExpectedConditions.visibilityOfElementLocated(alertWrongCode));
+            logger.info("Alert visualizzato correttamente in pagina");
+            WebElement alertCloseButton = driver.findElement(alertCloseButtonBy);
+            alertCloseButton.click();
+            logger.info("Alert chiusa");
+        } catch (TimeoutException e) {
+            logger.error("Alert non visualizzato con errore: " + e.getMessage());
+            Assert.fail("Alert non visualizzato con errore: " + e.getMessage());
+        }
+    }
+
+    public void clickButtonIndietroDaAssegnaGruppo() {
+        try {
+            logger.info("Si clicca sul bottone indietro per tornare al pop-up di inserimento codice delega");
+            By buttonIndietroPopUpAssegnaGruppo = By.xpath("//*[@data-testid='groupCancelButton']");
+            this.getWebDriverWait(10).until(ExpectedConditions.visibilityOfElementLocated(buttonIndietroPopUpAssegnaGruppo));
+            WebElement buttonIndietroClick = driver.findElement(buttonIndietroPopUpAssegnaGruppo);
+            buttonIndietroClick.click();
+            logger.info("Bottone indietro cliccato");
+        } catch (TimeoutException e) {
+            logger.error("Bottone non visualizzato con errore " + e.getMessage());
+            Assert.fail("Bottone non visualizzato con errore: " + e.getMessage());
+        }
+    }
+
+    public void checkTextboxCodiceSonoRosse() {
+        final String textboxIsInvalid = "true";
+        boolean isInvalid = true;
+        for (int i = 0; i < 5; i++) {
+            String xpathBy = "code-input-" + i;
+            By codiceDelegaInputBy = By.id(xpathBy);
+            getWebDriverWait(10).withMessage("Textbox di input codice delega non visualizzata").until(ExpectedConditions.visibilityOfElementLocated(codiceDelegaInputBy));
+            WebElement codiceDelegaInput = driver.findElement(codiceDelegaInputBy);
+            String stateInput = codiceDelegaInput.getAttribute("aria-invalid");
+            if (!textboxIsInvalid.equals(stateInput)) {
+                isInvalid = false;
+            }
+        }
+        if (isInvalid) {
+            logger.info("Textbox di input codice delega sono in stato invalido");
+        } else {
+            logger.error("Almeno una textbox di input codice delega non in stato invalido");
+            Assert.fail("Almeno una textbox di input codice delega non in stato invalido");
+        }
+    }
+
     public void checkTabellaDelegheACaricoDellImpresa() {
         By menuDelega = By.xpath("//table[@id='notifications-table']//following-sibling::td//button[@data-testid='delegationMenuIcon']");
         By colonnaNome = By.xpath("//table[@id='notifications-table']//th[contains(text(),'Nome')]");
@@ -349,7 +399,7 @@ public class DeleghePGPagoPAPage extends BasePage {
             getWebDriverWait(10).withMessage("colonna gruppi non caricata correttamente").until(ExpectedConditions.visibilityOfElementLocated(colonnaGruppi));
             getWebDriverWait(10).withMessage("colonna stato non caricata correttamente").until(ExpectedConditions.visibilityOfElementLocated(colonnaStato));
             getWebDriverWait(10).withMessage("menu non caricato correttamente").until(ExpectedConditions.visibilityOfElementLocated(menuDelega));
-        }catch (TimeoutException e){
+        } catch (TimeoutException e) {
             logger.error("tabella deleghe a carico dell impresa non caricata correttamente" + e.getMessage());
             Assert.fail("tabella deleghe a carico dell impresa non caricata correttamente" + e.getMessage());
         }

--- a/src/main/java/it/pn/frontend/e2e/pages/destinatario/personaGiuridica/DeleghePGPagoPAPage.java
+++ b/src/main/java/it/pn/frontend/e2e/pages/destinatario/personaGiuridica/DeleghePGPagoPAPage.java
@@ -75,6 +75,9 @@ public class DeleghePGPagoPAPage extends BasePage {
     @FindBy(id = "notifications-table")
     WebElement tabelleDelleDelegheACaricoDellImpresa;
 
+    @FindBy(id = "alert-api-status}")
+    WebElement alertPopUp;
+
 
     public DeleghePGPagoPAPage(WebDriver driver) {
         super(driver);
@@ -207,8 +210,7 @@ public class DeleghePGPagoPAPage extends BasePage {
 
     public boolean verificaEsistenzaErroreCodiceSbagliato() {
         try {
-            By esistenzaBy = By.id("alert-api-status}");
-            this.getWebDriverWait(5).until(ExpectedConditions.visibilityOfElementLocated(esistenzaBy));
+            this.getWebDriverWait(5).withMessage("Alert non visualizzato correttamente").until(ExpectedConditions.visibilityOf(alertPopUp));
             logger.info("Errore codice sbagliato trovato");
             return true;
         } catch (TimeoutException e) {
@@ -334,9 +336,8 @@ public class DeleghePGPagoPAPage extends BasePage {
 
     public void checkAlertWrongDelegationCode() {
         try {
-            By alertWrongCode = By.id("alert-api-status}");
             By alertCloseButtonBy = By.xpath("//button[@aria-label='Close']");
-            this.getWebDriverWait(10).withMessage("Alert non visualizzato correttamente").until(ExpectedConditions.visibilityOfElementLocated(alertWrongCode));
+            this.getWebDriverWait(5).withMessage("Alert non visualizzato correttamente").until(ExpectedConditions.visibilityOf(alertPopUp));
             logger.info("Alert visualizzato correttamente in pagina");
             WebElement alertCloseButton = driver.findElement(alertCloseButtonBy);
             alertCloseButton.click();

--- a/src/main/java/it/pn/frontend/e2e/pages/destinatario/personaGiuridica/PiattaformaNotifichePGPAPage.java
+++ b/src/main/java/it/pn/frontend/e2e/pages/destinatario/personaGiuridica/PiattaformaNotifichePGPAPage.java
@@ -112,7 +112,7 @@ public class PiattaformaNotifichePGPAPage extends BasePage {
 
     public void clickSuDelegeButton() {
         try {
-            this.getWebDriverWait(30).until(ExpectedConditions.visibilityOf(this.delegheSideMenu));
+            this.getWebDriverWait(10).withMessage("Sezione deleghe nel side menu non visualizzata").until(ExpectedConditions.visibilityOf(this.delegheSideMenu));
             this.js().executeScript("arguments[0].click()", this.delegheSideMenu);
             logger.info("click sul bottone Deleghe effetuato");
         } catch (TimeoutException e) {

--- a/src/test/java/it/pn/frontend/e2e/stepDefinitions/common/BackgroundTest.java
+++ b/src/test/java/it/pn/frontend/e2e/stepDefinitions/common/BackgroundTest.java
@@ -151,7 +151,6 @@ public class BackgroundTest {
 
 
     public void accettazioneDelegaSceltaGruppo(boolean withGroup) {
-        deleghePagoPATest.siSceglieOpzioneAccetta();
         deleghePGPagoPATest.siInserisceIlCodiceDellaDelegaACaricoDellImpresaNellaModale();
         deleghePGPagoPATest.nellaSezioneDelegheSiCliccaSulBottoneConfermaCodice();
         if (!withGroup) {

--- a/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaGiuridica/DeleghePGPagoPATest.java
+++ b/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaGiuridica/DeleghePGPagoPATest.java
@@ -11,6 +11,7 @@ import it.pn.frontend.e2e.rest.RestDelegation;
 import it.pn.frontend.e2e.section.destinatario.personaGiuridica.AggiungiDelegaPGSection;
 import it.pn.frontend.e2e.section.destinatario.personaGiuridica.DelegatiImpresaSection;
 import it.pn.frontend.e2e.stepDefinitions.common.BackgroundTest;
+import it.pn.frontend.e2e.stepDefinitions.destinatario.personaFisica.DeleghePagoPATest;
 import it.pn.frontend.e2e.utility.DataPopulation;
 import org.junit.Assert;
 import org.openqa.selenium.WebDriver;
@@ -27,6 +28,7 @@ public class DeleghePGPagoPATest {
     private final Logger logger = LoggerFactory.getLogger("DeleghePGPagoPATest");
     private final WebDriver driver = Hooks.driver;
     private final DeleghePGPagoPAPage deleghePGPagoPAPage = new DeleghePGPagoPAPage(this.driver);
+    private final DeleghePagoPATest deleghePagoPATest = new DeleghePagoPATest();
     private final DelegatiImpresaSection delegatiImpresaSection = new DelegatiImpresaSection(this.driver);
     private final AggiungiDelegaPGSection aggiungiDelegaPGSection = new AggiungiDelegaPGSection(this.driver);
     private final DataPopulation dataPopulation = new DataPopulation();
@@ -152,8 +154,8 @@ public class DeleghePGPagoPATest {
         }
     }
 
-    @And("Nella sezione Le Tue Deleghe inserire una data con formato errato e andecedente alla data")
-    public void nellaSezioneLeTueDelegheInserireUnaDataConFormatoErratoEAndecedenteAllaData() {
+    @And("Nella sezione Le Tue Deleghe inserire una data con formato errato e antecedente alla data")
+    public void nellaSezioneLeTueDelegheInserireUnaDataConFormatoErratoEAntecedenteAllaData() {
         logger.info("Si inserisce una data errata e antecedente");
 
         aggiungiDelegaPGSection.clearInputData();
@@ -528,5 +530,23 @@ public class DeleghePGPagoPATest {
     @And("Si controlla la tabella delegati dall impresa")
     public void siControllaLaTabellaDelegatiDallImpresa() {
         delegatiImpresaSection.checkTabellaDelegheDellImpresa();
+    }
+
+    @And("Si inserisce un codice della delega a carico dell impresa errato nella modale")
+    public void siInserisceUnCodiceDellaDelegaACaricoDellImpresaErratoNellaModale() {
+        logger.info("Si inserisce un codice della delega errato nella modale");
+        deleghePagoPATest.siSceglieOpzioneAccetta();
+        String verificationCode = "00000";
+        deleghePGPagoPAPage.inserimentoCodiceDelegaACaricoDellImpresaAPI(verificationCode);
+        nellaSezioneDelegheSiCliccaSulBottoneConfermaCodice();
+        deleghePGPagoPAPage.clickBottoneConferma();
+    }
+
+    @Then("Le textbox che contengono le cifre del codice delega diventano rosse")
+    public void leTextboxCheContengonoLeCifreDelCodiceDelegaDiventanoRosse() {
+        logger.info("Si visualizza alert di errore in pagina");
+        deleghePGPagoPAPage.checkAlertWrongDelegationCode();
+        deleghePGPagoPAPage.clickButtonIndietroDaAssegnaGruppo();
+        deleghePGPagoPAPage.checkTextboxCodiceSonoRosse();
     }
 }

--- a/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaGiuridica/DeleghePGPagoPATest.java
+++ b/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaGiuridica/DeleghePGPagoPATest.java
@@ -538,7 +538,7 @@ public class DeleghePGPagoPATest {
         deleghePagoPATest.siSceglieOpzioneAccetta();
         String verificationCode = "00000";
         deleghePGPagoPAPage.inserimentoCodiceDelegaACaricoDellImpresaAPI(verificationCode);
-        nellaSezioneDelegheSiCliccaSulBottoneConfermaCodice();
+        deleghePGPagoPAPage.clickConfirmCodeButton();
         deleghePGPagoPAPage.clickBottoneConferma();
     }
 

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/002_113_neg_aggiuntaDelegaErrorePG.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/002_113_neg_aggiuntaDelegaErrorePG.feature
@@ -13,6 +13,6 @@ Feature: La persona giuridica aggiunge una nuova delga inserendo una data errata
     And Si visualizza correttamente la pagina Deleghe sezione Deleghe dell impresa
     And Nella sezione Delegati dell impresa click sul bottone aggiungi nuova delega
     And Si visualizza la sezione Aggiungi Delega persona giuridica
-    And Nella sezione Le Tue Deleghe inserire una data con formato errato e andecedente alla data
+    And Nella sezione Le Tue Deleghe inserire una data con formato errato e antecedente alla data
     And Nella sezione Le Tue Deleghe si visualizza il messaggio di errore data errata
     And Logout da portale persona giuridica

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/004_119_accettazioneDelegaSenzaGruppo.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghePG/004_119_accettazioneDelegaSenzaGruppo.feature
@@ -15,6 +15,8 @@ Feature:Il delegato persona giuridica accetta la delega non assegnandoli un grup
       | companyName    | Convivio Spa  |
       | displayName    | Convivio Spa  |
       | person         | false         |
+    And Si inserisce un codice della delega a carico dell impresa errato nella modale
+    Then Le textbox che contengono le cifre del codice delega diventano rosse
     And Si accetta la delega "senza" gruppo
     And Si controlla che la delega PG ha lo stato Attiva "Convivio Spa"
     And Logout da portale persona giuridica


### PR DESCRIPTION
## Short description

PN - 9171 - implemented new steps

## List of changes proposed in this pull request

implemented new steps on test PGAccettazioneDelegaSenzaGruppo feature file 004_119
added the insertion of an incorrect delegation code
added control on input textbox turning red on wrong code insertion

## How to test

Create a delegation, then accept it with a wrong code. You should visualize an error message and the input textbox for the delegation code should be red. Then proceed with the correct code and accept the delegation.

- [ x ] Does this PR require a manual test in AWS CodeBuild?