### PR TITLE
PN-10425-e-2-e-destinatario-pf-creazione-delega-ente-radice-verifica-assenza-ente-figlio

### DIFF
--- a/src/main/java/it/pn/frontend/e2e/pages/destinatario/DestinatarioPage.java
+++ b/src/main/java/it/pn/frontend/e2e/pages/destinatario/DestinatarioPage.java
@@ -32,6 +32,7 @@ public class DestinatarioPage extends BasePage {
     @FindBy(id = "notificationsTable.body.row")
     List<WebElement> listaNotificheDelegante;
 
+
     public void inserimentoDataErrato() {
         String data = "01/01/1111";
         getWebDriverWait(10).withMessage("Il campo data inizio non è visibile").until(ExpectedConditions.visibilityOfAllElements(this.dataInizioField));
@@ -44,27 +45,27 @@ public class DestinatarioPage extends BasePage {
         getWebDriverWait(3).withMessage("Il valore della data che si vuole inserire non corrisponde").until(ExpectedConditions.attributeToBe(this.dataFineField, "value", data));
     }
 
-    public boolean isDateBoxInvalid(){
+    public boolean isDateBoxInvalid() {
         final String isTextboxInvalid = "true";
         boolean invalidBoxDate = true;
         try {
             getWebDriverWait(10).withMessage("Il campo data inizio non è visibile").until(ExpectedConditions.visibilityOfAllElements(this.dataInizioField, this.dataFineField));
             String ariaInvalidInizio = dataInizioField.getAttribute("aria-invalid");
             String ariaInvalidFine = dataFineField.getAttribute("aria-invalid");
-            if(isTextboxInvalid.equals(ariaInvalidInizio) || isTextboxInvalid.equals(ariaInvalidFine)){
+            if (isTextboxInvalid.equals(ariaInvalidInizio) || isTextboxInvalid.equals(ariaInvalidFine)) {
                 logger.info("Almeno un campo data è in stato invalido");
-            }else{
+            } else {
                 logger.error("Nessuno dei campi data è passato allo stato invalido");
                 Assert.fail("Nessuno dei campi data è passato allo stato invalido");
             }
-        } catch (TimeoutException e){
+        } catch (TimeoutException e) {
             logger.error("Campi data non visualizzati correttamente con errore: " + e.getMessage());
             Assert.fail("Campi data non visualizzati correttamente con errore: " + e.getMessage());
         }
         return invalidBoxDate;
     }
 
-    public void clickButtonNotificheDelegateOnSideMenu(String nomeDelegante){
+    public void clickButtonNotificheDelegateOnSideMenu(String nomeDelegante) {
         logger.info("verifica bottone notifiche nel layout");
 
         getWebDriverWait(10).until(ExpectedConditions.visibilityOf(this.sideItemNotificheButton));
@@ -77,17 +78,43 @@ public class DestinatarioPage extends BasePage {
 
     }
 
-    public void clickSulDettaglioNotificaDelegante(){
+    public void clickSulDettaglioNotificaDelegante() {
         WebElement singolaNotificaDelegante = listaNotificheDelegante.get(0);
         getWebDriverWait(10).withMessage("la prima notifica della tabella non è visibile").until(ExpectedConditions.visibilityOf(singolaNotificaDelegante));
         logger.info("Si clicca sulla prima notifica del delegante");
         singolaNotificaDelegante.click();
     }
 
-    public void clickProdotto(String xpath){
+    public void clickProdotto(String xpath) {
         By prodottoDestinatario = By.xpath(xpath);
         getWebDriverWait(10).withMessage("prodotto non disponbile").until(ExpectedConditions.visibilityOfElementLocated(prodottoDestinatario));
         element(prodottoDestinatario).click();
     }
+
+    public void clickTuttiGliEnti() {
+        By tuttiGliEnti = By.id("tutti-gli-enti-selezionati");
+        getWebDriverWait(10).withMessage("Il radio button 'tutti gli enti selezionati' non è visibile").until(ExpectedConditions.visibilityOfElementLocated(tuttiGliEnti));
+        element(tuttiGliEnti).click();
+    }
+
+    public void clickSoloEntiSelezionati() {
+        By soloEntiSelezionati = By.id("enti-selezionati");
+        getWebDriverWait(10).withMessage("Il radio button 'solo enti selezionati' non è visibile").until(ExpectedConditions.visibilityOfElementLocated(soloEntiSelezionati));
+        element(soloEntiSelezionati).click();
+    }
+
+    public void clickListaEnti() {
+        By listaEnti = By.id("enti");
+        getWebDriverWait(10).withMessage("Il menù a tendina degli enti non è visibile").until(ExpectedConditions.visibilityOfElementLocated(listaEnti));
+        element(listaEnti).click();
+    }
+
+    public void controlloEntiRadice(List<String> enti) {
+        for (String ente : enti) {
+            By enteRadice = By.xpath("//li//p[contains(text(),'" + ente + "')]");
+            getWebDriverWait(10).withMessage("Ente: " + ente + " non visibile").until(ExpectedConditions.visibilityOfElementLocated(enteRadice));
+        }
+    }
+
 
 }

--- a/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaFisica/DeleghePagoPATest.java
+++ b/src/test/java/it/pn/frontend/e2e/stepDefinitions/destinatario/personaFisica/DeleghePagoPATest.java
@@ -24,8 +24,10 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
 @Slf4j
 public class DeleghePagoPATest {
 
@@ -237,7 +239,7 @@ public class DeleghePagoPATest {
         leTueDelegheSection.waitPopUpLoad();
         if (data.equalsIgnoreCase("corretto")) {
             verificationCode = System.getProperty("verificationCode");
-        }else {
+        } else {
             verificationCode = "54321";
         }
         leTueDelegheSection.inserireCodiceDelega(verificationCode);
@@ -290,17 +292,18 @@ public class DeleghePagoPATest {
     }
 
     @And("Si vefifica il messaggio di codice sbagliato")
-    public void siVerificaIlMessaggioDiCodiceSbagliato(){
+    public void siVerificaIlMessaggioDiCodiceSbagliato() {
         if (leTueDelegheSection.verificaEsistenzaErroreCodiceSbagliato()) {
             log.info("Il messaggio di codice sbagliato è visualizzata");
-        }else{
+        } else {
             log.error("Il messaggio di codice sbagliato non è visualizzata");
             Assert.fail("Il messaggio di codice sbagliato non è visualizzata");
         }
 
     }
+
     @And("Si clicca sul bottone indietro popup")
-    public void siCliccaSulBottoneIndietroPopUp(){
+    public void siCliccaSulBottoneIndietroPopUp() {
         leTueDelegheSection.clickIndietroButton();
     }
 
@@ -313,7 +316,7 @@ public class DeleghePagoPATest {
     }
 
     @And("Si controlla che la delega ha lo stato Attiva")
-    public void siControllaCheLaDelegaHaLoStatoAttiva(Map<String,String> data) {
+    public void siControllaCheLaDelegaHaLoStatoAttiva(Map<String, String> data) {
         log.info("Si controlla che la delega abbia lo stato Attiva");
         leTueDelegheSection.controlloStatoAttiva(data.get("firstName"), data.get("lastName"));
     }
@@ -411,7 +414,7 @@ public class DeleghePagoPATest {
     }
 
     @And("Nella pagina Deleghe si clicca sul menu della delega a tuo carico")
-    public void nellaPaginaDelegheSiCliccaSulMenuDellaDelega(Map<String,String> personaFisica) {
+    public void nellaPaginaDelegheSiCliccaSulMenuDellaDelega(Map<String, String> personaFisica) {
         log.info("Si clicca sul menu delle delega");
         String nome = personaFisica.get("nome");
         String cognome = personaFisica.get("cognome");
@@ -482,7 +485,7 @@ public class DeleghePagoPATest {
     }
 
     @And("Si verifica sia presente una delega da rifiutare nella sezione Deleghe a Tuo Carico")
-    public void siVerificaSiaPresenteUnaDelegaDaRifiutareNellaSezioneDelegheATuoCarico(Map<String,String> personaFisica) {
+    public void siVerificaSiaPresenteUnaDelegaDaRifiutareNellaSezioneDelegheATuoCarico(Map<String, String> personaFisica) {
         log.info("Si controlla che ci sia almeno una delega");
 
         String nome = personaFisica.get("nome");
@@ -512,6 +515,7 @@ public class DeleghePagoPATest {
             Assert.fail("La delega è ancora presente in lista");
         }
     }
+
     @And("Si annulla azione revoca")
     public void siAnnullaAzioneRevoca() {
         deleghePage.clickAnnullaRevoca();
@@ -529,8 +533,29 @@ public class DeleghePagoPATest {
     }
 
     @And("Si verifica che presente un indicatore numerico in corrispondenza della voce di menù Deleghe")
-    public void siVerificaIndicatoreNumericoMenuDeleghe(){
+    public void siVerificaIndicatoreNumericoMenuDeleghe() {
         log.info("Si controlla indicatore numerico");
-       leTueDelegheSection.checkIndicatoreNumerico();
+        leTueDelegheSection.checkIndicatoreNumerico();
+    }
+
+    /**
+     * @param tipoVisualizzazioneNotifica i valori possibili sono: Tutti gli enti o Solo enti selezionati
+     * @param tipoUtente
+     */
+    @Then("Nella sezione della nuova delega si sceglie la visualizzazione delle notifiche da parte di: {string}")
+    public void nellaSezioneSiSceglieLaVisualizzazioneDelleNotificheDaParteDi(String tipoVisualizzazioneNotifica) {
+        log.info("Si sceglie la visualizzazione delle notifiche");
+        if (tipoVisualizzazioneNotifica.equalsIgnoreCase("Tutti gli enti")) {
+            destinatarioPage.clickTuttiGliEnti();
+        } else {
+            destinatarioPage.clickSoloEntiSelezionati();
+        }
+    }
+
+    @And("Si verifica che nell'elenco degli enti sono presenti solamente enti radice")
+    public void siVerificaCheNellElencoDegliEntiSonoPresentiSolamenteEntiRadice(List<String> enti) {
+        log.info("Si verifica che nell'elenco degli enti sono presenti solamente enti radice");
+        destinatarioPage.clickListaEnti();
+        destinatarioPage.controlloEntiRadice(enti);
     }
 }

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghe/012_01_creazioneDelegaEnteRadice.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghe/012_01_creazioneDelegaEnteRadice.feature
@@ -1,0 +1,32 @@
+Feature: persona fisica aggiunge una delega dall'elenco degli enti radice
+
+  @TestSuite
+  @TA_PFaggiuntaDelegaEnteRadice
+  @DeleghePF
+  @PF
+
+  Scenario:PN-10425 - La persona fisica aggiunge una delega dall'elenco enti radice
+    Given PF - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
+    When Nella pagina Piattaforma Notifiche persona fisica click sul bottone Deleghe
+    And Nella pagina Piattaforma Notifiche persona fisica si vede la sezione Deleghe
+    And Nella sezione Deleghe click sul bottone aggiungi nuova delega
+    And Nella sezione Le Tue Deleghe inserire i dati
+      | nome          | Lucrezia         |
+      | cognome       | Borgia           |
+      | codiceFiscale | BRGLRZ80D58H501Q |
+      | ente          | Comune di Verona |
+    Then Nella sezione della nuova delega si sceglie la visualizzazione delle notifiche da parte di: "solo enti selezionati"
+    And Si verifica che nell'elenco degli enti sono presenti solamente enti radice
+      | Agenzia delle Entrate        |
+      | Comune di Afragola           |
+      | Comune di Caserta            |
+      | Comune di Cotronei           |
+      | Comune di Mercenasco         |
+      | Comune di Palmanova          |
+      | Comune di Trivignano Udinese |
+      | Comune di Vibo Valentia      |
+      | Istituto Nazionale           |
+      | Mercurio Riscossioni         |
+    And Nella sezione Le Tue Deleghe click sul bottone Invia richiesta e sul bottone torna alle deleghe
+    And Nella sezione Deleghe si visualizza la delega in stato di attesa di conferma
+    And Logout da portale persona fisica

--- a/src/test/resources/feature/3-destinatario/personaFisica/deleghe/012_01_creazioneDelegaEnteRadice.feature
+++ b/src/test/resources/feature/3-destinatario/personaFisica/deleghe/012_01_creazioneDelegaEnteRadice.feature
@@ -29,4 +29,10 @@ Feature: persona fisica aggiunge una delega dall'elenco degli enti radice
       | Mercurio Riscossioni         |
     And Nella sezione Le Tue Deleghe click sul bottone Invia richiesta e sul bottone torna alle deleghe
     And Nella sezione Deleghe si visualizza la delega in stato di attesa di conferma
+    And Nella sezione Deleghe si clicca sul menu della delega
+      | nome    | Lucrezia |
+      | cognome | Borgia   |
+    And Nella sezione Deleghe si sceglie l'opzione revoca
+    And Si conferma l'azione scegliendo revoca la delega
+    Then Si controlla che non ci sia più una delega
     And Logout da portale persona fisica


### PR DESCRIPTION
## Short description

There isn't a test related to the PN-10425 as you can see in the [confluence page](https://pagopa.atlassian.net/wiki/spaces/PN/pages/868811083)

## List of changes proposed in this pull request

- added new feature file `012_01_creazioneDelegaEnteRadice`
- added into `DestinatarioPage` new method:  `clickTuttiGliEnti() ` ,  `clickSoloEntiSelezionati()`,  `clickListaEnti()`,  `controlloEntiRadice()`
- added 2 feature steps related to the test

- [x] Does this PR require a manual test in AWS CodeBuild?

[Report of the test](https://eu-south-1.console.aws.amazon.com/codesuite/codebuild/151559006927/testReports/reports/pn-RunFeE2eTestsCodeBuildProject-reportGroup/pn-RunFeE2eTestsCodeBuildProject-reportGroup%3A05006083-ab78-46e9-8fa6-9c2644d04c2a?region=eu-south-1)