### PR TITLE
PN-10429-e-2-e-destinatario-pg-creazione-delega-ente-radice-verifica-assenza-ente-figlio

### DIFF
--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghe/017_001_creazioneDelegaEnteRadice.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghe/017_001_creazioneDelegaEnteRadice.feature
@@ -33,4 +33,4 @@ Feature: persona giuridica aggiunge una delega dall'elenco degli enti radice
     And Nella sezione Deleghe si visualizza la delega in stato di attesa di conferma
     And Si controlla che non sia presente una delega con stesso nome persona giuridica "Le Epistolae srl"
     And Nella sezione Deleghe sezione Deleghe dell'impresa si controlla che non sia più presente la delega "nuovaDelegaPG"
-    And Logout da portale persona fisica
+    And Logout da portale persona giuridica

--- a/src/test/resources/feature/3-destinatario/personaGiuridica/deleghe/017_001_creazioneDelegaEnteRadice.feature
+++ b/src/test/resources/feature/3-destinatario/personaGiuridica/deleghe/017_001_creazioneDelegaEnteRadice.feature
@@ -1,0 +1,36 @@
+Feature: persona giuridica aggiunge una delega dall'elenco degli enti radice
+
+  @TestSuite
+  @TA_PGaggiuntaDelegaEnteRadice
+  @DeleghePG
+  @PG
+
+  Scenario:PN-10429 - La persona giuridica aggiunge una delega dall'elenco enti radice
+    Given PG - Si effettua la login tramite token exchange come "delegante", e viene visualizzata la dashboard
+    When Nella pagina Piattaforma Notifiche persona giuridica click sul bottone Deleghe
+    And Si visualizza correttamente la pagina Deleghe sezione Deleghe a Carico dell impresa
+    And Nella pagina Deleghe si clicca su Delegati dall impresa
+    And Si visualizza correttamente la pagina Deleghe sezione Deleghe dell impresa
+    And Nella sezione Delegati dell impresa click sul bottone aggiungi nuova delega
+    And Nella sezione Aggiungi Delega persona giuridica inserire i dati
+      | accessoCome    | delegante         |
+      | ragioneSociale | Le Epistolae srl  |
+      | codiceFiscale  | LELPTR04A01C352E  |
+      | ente           | Comune di Palermo |
+    Then Nella sezione della nuova delega si sceglie la visualizzazione delle notifiche da parte di: "solo enti selezionati"
+    And Si verifica che nell'elenco degli enti sono presenti solamente enti radice
+      | Agenzia delle Entrate        |
+      | Comune di Afragola           |
+      | Comune di Caserta            |
+      | Comune di Cotronei           |
+      | Comune di Mercenasco         |
+      | Comune di Palmanova          |
+      | Comune di Trivignano Udinese |
+      | Comune di Vibo Valentia      |
+      | Istituto Nazionale           |
+      | Mercurio Riscossioni         |
+    And Nella sezione Le Tue Deleghe click sul bottone Invia richiesta e sul bottone torna alle deleghe
+    And Nella sezione Deleghe si visualizza la delega in stato di attesa di conferma
+    And Si controlla che non sia presente una delega con stesso nome persona giuridica "Le Epistolae srl"
+    And Nella sezione Deleghe sezione Deleghe dell'impresa si controlla che non sia più presente la delega "nuovaDelegaPG"
+    And Logout da portale persona fisica


### PR DESCRIPTION
## Short description

There isn't a test related to the PN-10429 as you can see in the [confluence page](https://pagopa.atlassian.net/wiki/spaces/PN/pages/869335156/Impresa+-+Mapping+test-scenari)

## List of changes proposed in this pull request

- added new feature file `017_001_creazioneDelegaEnteRadice`
- [x] Does this PR require a manual test in AWS CodeBuild?

[Report of the test](https://eu-south-1.console.aws.amazon.com/codesuite/codebuild/151559006927/testReports/reports/pn-RunFeE2eTestsCodeBuildProject-reportGroup/pn-RunFeE2eTestsCodeBuildProject-reportGroup%3A9cef2f8b-201b-462c-bb3a-0b3686eae6ce?region=eu-south-1)